### PR TITLE
enh: add a mechanism to process metadata

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -1,13 +1,16 @@
-DANDI_SCHEMA_VERSION = "0.5.1"
-ALLOWED_INPUT_SCHEMAS = ["0.3.0", "0.3.1", "0.4.0", "0.4.1", "0.4.2", "0.4.3", "0.4.4"]
+schema_info = {
+    "version": "1.0.0",
+    "schema_version": "0.5.1",
+    "process": {"0.5.1": None, "0.4.4": "migrate"},
+}
+
+DANDI_SCHEMA_VERSION = schema_info["schema_version"]
+ALLOWED_SCHEMAS = list(schema_info["process"])
 
 # ATM we allow only for a single target version which is current
 # migrate has a guard now for this since it cannot migrate to anything but current
 # version
 ALLOWED_TARGET_SCHEMAS = [DANDI_SCHEMA_VERSION]
-# This allows multiple schemas for validation, whereas target schemas focus on
-# migration.
-ALLOWED_VALIDATION_SCHEMAS = ALLOWED_TARGET_SCHEMAS + ["0.4.4"]
 
-if DANDI_SCHEMA_VERSION not in ALLOWED_INPUT_SCHEMAS:
-    ALLOWED_INPUT_SCHEMAS.append(DANDI_SCHEMA_VERSION)
+if DANDI_SCHEMA_VERSION not in ALLOWED_SCHEMAS:
+    ALLOWED_SCHEMAS.append(DANDI_SCHEMA_VERSION)


### PR DESCRIPTION
This PR adds the ability to process versions of schema to automate migration when possible. We can use comments here to work through the design and use cases.

One use case is to allow dandi api server to perform migrations on save.