### PR TITLE
Properly include "data packages" in project

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,8 +33,11 @@ install_requires =
     typing_extensions;  python_version < "3.8"
     requests
 zip_safe = False
-packages = find:
+packages = find_namespace:
 include_package_data = True
+
+[options.packages.find]
+include = dandischema*
 
 [options.extras_require]
 # I bet will come handy


### PR DESCRIPTION
There is a folder in `dandischema/` that contains data files but no Python source code, and we want this folder to be included when dandischema is installed.  Currently, this folder is automatically included by the combination of `graft dandischema` in `MANIFEST.in` and `include_package_data = True` in `setup.cfg`, but because we set `packages` in `setup.cfg` to `find:` instead of `find_namespace:`, the folder itself is not recognized by setuptools as a package.  [This combination of settings is deprecated](https://github.com/pypa/setuptools/issues/3340), and the setuptools developers recommend using `find_namespace:` instead of `find:` for such situations.