### PR TITLE
DOC: embargoedUntil -- extend semantic to be able to mark with the date when it was unembargoed

### DIFF
--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -611,7 +611,7 @@ class AccessRequirements(DandiBaseModel):
     embargoedUntil: Optional[date] = Field(
         None,
         title="Embargo end date",
-        description="Date on which embargo ends.",
+        description="Date on which embargo ends or ended.",
         readOnly=True,
         nskey="dandi",
         rangeIncludes="schema:Date",


### PR DESCRIPTION
The motivation is to (ab)use this metadata field to enable annotating dandisets which were unembargoed in the archive. ATM it would be impossible (?) to tell from dandiset metadata if it was unemabrgoed since we do not carry much (if any) of provenance.  Whenever we unemabrgo a dandiset we could use this field then  to fill-in datetime for when it was unembargoed, which would actually be "semantically" correct since that would be the date time until when it was embargoed.  Of cause if the intention of this field is more of "unembargoUntil" (so no "done" notion), then it must remain as is.

If merged -- TODO: file an issue with dandi-archive to fill-in this field (possibly overwriting an existing value) upon "unembargo" action for the dandiset.