### PR TITLE
Update pre-commit hooks and rerun

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,22 +2,22 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.3.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.8.0
     hooks:
     -   id: black
 -   repo: https://github.com/PyCQA/isort
-    rev: 5.7.0
+    rev: 5.10.1
     hooks:
     -   id: isort
 -   repo: https://github.com/codespell-project/codespell
-    rev: v2.0.0
+    rev: v2.2.1
     hooks:
     -   id: codespell
 -   repo: https://gitlab.com/pycqa/flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,7 +259,7 @@
 - Set DANDI_ALLOW_LOCALHOST_URLS when running dandi-cli tests [#66](https://github.com/dandi/dandischema/pull/66) ([@jwodder](https://github.com/jwodder))
 - RF(CI): run dandi-cli tests only against 3.8 (but all OSes) [#64](https://github.com/dandi/dandischema/pull/64) ([@yarikoptic](https://github.com/yarikoptic))
 - Run dandi-cli tests with dandi-api image built with local version of dandischema [#63](https://github.com/dandi/dandischema/pull/63) ([@jwodder](https://github.com/jwodder))
-- fix: change id to indentifier for software [#46](https://github.com/dandi/dandischema/pull/46) ([@satra](https://github.com/satra))
+- fix: change id to identifier for software [#46](https://github.com/dandi/dandischema/pull/46) ([@satra](https://github.com/satra))
 - Add workflow for testing dandischema against latest release of dandi-cli [#49](https://github.com/dandi/dandischema/pull/49) ([@jwodder](https://github.com/jwodder))
 
 #### Authors: 4

--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ To use: `pip install dandischema`
 Every Dandiset and associated asset has a metadata object that can be retrieved using
 the DANDI API.
 
-This library uses [Pydantic](https://github.com/samuelcolvin/pydantic) to implement 
-all the metadata classes. Schemas are generated on schema modifications and placed into 
-[this repository](https://github.com/dandi/schema/tree/master/releases). 
+This library uses [Pydantic](https://github.com/samuelcolvin/pydantic) to implement
+all the metadata classes. Schemas are generated on schema modifications and placed into
+[this repository](https://github.com/dandi/schema/tree/master/releases).
 
-Dandischema generates JSON schema definitions and also an associated `context.json` 
-file for JSON-LD compliance of the metadata models. 
+Dandischema generates JSON schema definitions and also an associated `context.json`
+file for JSON-LD compliance of the metadata models.
 
 - models.py - contains the models and any changes should be made there
 - metadata.py - contains functions for validating, migrating, and aggregating metadata
 - datacite.py - converts the Dandiset metadata to a Datacite metadata structure
 
-The generated JSON schemas can be used together with 
-[VJSF](https://koumoul-dev.github.io/vuetify-jsonschema-form/latest/) to create a UI 
+The generated JSON schemas can be used together with
+[VJSF](https://koumoul-dev.github.io/vuetify-jsonschema-form/latest/) to create a UI
 for metadata modification. The DANDI Web app uses this for Dandiset metadata modification.

--- a/dandischema/datacite.py
+++ b/dandischema/datacite.py
@@ -67,7 +67,7 @@ def to_datacite(
 
     attributes = {}
     if publish:
-        attributes['event'] = 'publish'
+        attributes["event"] = "publish"
 
     attributes["identifiers"] = [
         # TODO: the first element is ignored, not sure how to fix it...
@@ -199,7 +199,9 @@ def to_datacite(
                         ident_id = rel_el.identifier.split("doi.org/")[1]
                     elif "biorxiv.org/" in rel_el.identifier:
                         ident_tp = "DOI"
-                        ident_id = rel_el.identifier.split("biorxiv.org/content/")[1].split("v")[0]
+                        ident_id = rel_el.identifier.split("biorxiv.org/content/")[
+                            1
+                        ].split("v")[0]
                     # if any other url is passed
                     elif rel_el.identifier.startswith("https://"):
                         ident_id = rel_el.identifier

--- a/dandischema/digests/dandietag.py
+++ b/dandischema/digests/dandietag.py
@@ -10,15 +10,15 @@ from typing import Iterator, List, NamedTuple, Optional, Union
 
 
 def mb(bytes_size: int) -> int:
-    return bytes_size * 2 ** 20
+    return bytes_size * 2**20
 
 
 def gb(bytes_size: int) -> int:
-    return bytes_size * 2 ** 30
+    return bytes_size * 2**30
 
 
 def tb(bytes_size: int) -> int:
-    return bytes_size * 2 ** 40
+    return bytes_size * 2**40
 
 
 class Part(NamedTuple):

--- a/dandischema/exceptions.py
+++ b/dandischema/exceptions.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List
+
 import jsonschema.exceptions
 
 
@@ -11,6 +12,7 @@ class JsonschemaValidationError(ValidationError):
 
     All errors are contained in the .args[0] of the exception instance.
     """
+
     @property
     def errors(self) -> List[jsonschema.exceptions.ValidationError]:
         return self.args[0]
@@ -21,6 +23,7 @@ class PydanticValidationError(ValidationError):
 
     All errors are contained in the .args[0] of the exception instance.
     """
+
     @property
     def errors(self) -> List[Dict[str, Any]]:
         return self.args[0]

--- a/dandischema/tests/test_datacite.py
+++ b/dandischema/tests/test_datacite.py
@@ -128,7 +128,7 @@ def _basic_publishmeta(dandi_id, version="0.0.0", prefix="10.80507"):
 )
 @pytest.mark.parametrize("dandi_id", ["000004", "000008"])
 def test_datacite(dandi_id, schema):
-    """ checking to_datacite for a specific datasets"""
+    """checking to_datacite for a specific datasets"""
 
     # reading metadata taken from exemplary dandisets and saved in json files
     with (
@@ -232,7 +232,7 @@ def test_datacite(dandi_id, schema):
                             RoleType("dcite:Author"),
                             RoleType("dcite:Software"),
                         ],
-                        "identifier": "0000-0001-0000-0000"
+                        "identifier": "0000-0001-0000-0000",
                     },
                     {
                         "name": "B_last, B_first",
@@ -241,22 +241,32 @@ def test_datacite(dandi_id, schema):
                 ],
             },
             {
-                "creators": (1, {"name": "A_last, A_first",
-                                 'nameIdentifiers': [{
-                                     "nameIdentifier": "0000-0001-0000-0000",
-                                     "nameIdentifierScheme": "ORCID",
-                                     "schemeUri": "https://orcid.org/",
-                                 }],
-                                 }),
+                "creators": (
+                    1,
+                    {
+                        "name": "A_last, A_first",
+                        "nameIdentifiers": [
+                            {
+                                "nameIdentifier": "0000-0001-0000-0000",
+                                "nameIdentifierScheme": "ORCID",
+                                "schemeUri": "https://orcid.org/",
+                            }
+                        ],
+                    },
+                ),
                 "contributors": (
                     2,
-                    {"name": "A_last, A_first", "contributorType": "Other",
-                     'nameIdentifiers': [{
-                         "nameIdentifier": "0000-0001-0000-0000",
-                         "nameIdentifierScheme": "ORCID",
-                         "schemeUri": "https://orcid.org/",
-                     }],
-                     },
+                    {
+                        "name": "A_last, A_first",
+                        "contributorType": "Other",
+                        "nameIdentifiers": [
+                            {
+                                "nameIdentifier": "0000-0001-0000-0000",
+                                "nameIdentifierScheme": "ORCID",
+                                "schemeUri": "https://orcid.org/",
+                            }
+                        ],
+                    },
                 ),
             },
         ),


### PR DESCRIPTION
This addresses a fatal problem with an older version of black using a now-removed private part of click.