### PR TITLE
Update GitHub Actions action versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,11 +10,11 @@ jobs:
 
     steps:
     - name: Set up environment
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:  # no need for the history
         fetch-depth: 1
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: '3.7'
     - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       auto-version: ${{ steps.auto-version.outputs.version }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # A full checkout is required so that auto will have access to tag
           # information.
@@ -44,7 +44,7 @@ jobs:
     if: needs.release-check.outputs.auto-version != ''
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           path: dandischema
@@ -56,7 +56,7 @@ jobs:
         working-directory: dandischema
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.7
 
@@ -74,7 +74,7 @@ jobs:
           echo "SCHEMA_VERSION=$SCHEMA_VERSION" >> "$GITHUB_ENV"
 
       - name: Checkout dandi/schema
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: dandi/schema
           path: schema

--- a/.github/workflows/test-dandi-cli.yml
+++ b/.github/workflows/test-dandi-cli.yml
@@ -48,7 +48,7 @@ jobs:
             python: 3.9
     steps:
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -78,7 +78,7 @@ jobs:
         run: echo DANDI_DEVEL=1 >> "$GITHUB_ENV"
 
       - name: Check out dandischema
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Fetch all commits so that versioningit will return something
           # compatible with semantic-version

--- a/.github/workflows/test-nonetwork.yml
+++ b/.github/workflows/test-nonetwork.yml
@@ -25,14 +25,14 @@ jobs:
           - '3.10'
     steps:
       - name: Set up environment
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Fetch all commits so that versioningit will return something
           # compatible with semantic-version
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -47,7 +47,7 @@ jobs:
           DANDI_TESTS_NONETWORK: 1
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
           flags: unittests

--- a/.github/workflows/test-schema.yml
+++ b/.github/workflows/test-schema.yml
@@ -11,13 +11,13 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'release')
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Need history for `git describe`
           path: dandischema
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
 
@@ -26,7 +26,7 @@ jobs:
         working-directory: dandischema
 
       - name: Checkout dandi/schema
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: dandi/schema
           path: schema

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,14 +26,14 @@ jobs:
           - '3.10'
     steps:
     - name: Set up environment
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # Fetch all commits so that versioningit will return something
         # compatible with semantic-version
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
 
@@ -46,7 +46,7 @@ jobs:
       run: tox -e py -- -s --cov-report=xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml
         flags: unittests


### PR DESCRIPTION
We are currently using older versions of the updated GitHub Actions actions, and these older versions still use Node 12, [which is deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).