### PR TITLE
Update GitHub Actions to use ubuntu-latest

### DIFF
--- a/.github/workflows/test-dandi-cli.yml
+++ b/.github/workflows/test-dandi-cli.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os:
           - windows-2019
-          - ubuntu-18.04
+          - ubuntu-latest
           - macos-latest
         python:
           # Use the only Python which is ATM also used by dandi-api
@@ -33,11 +33,11 @@ jobs:
         mode:
           - normal
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             python: 3.8
             mode: dandi-devel
             version: master
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             python: 3.8
             mode: dandi-devel
             version: release

--- a/.github/workflows/test-nonetwork.yml
+++ b/.github/workflows/test-nonetwork.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os:
           - windows-2019
-          - ubuntu-18.04
+          - ubuntu-latest
           - macos-latest
         python:
           - 3.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os:
           - windows-2019
-          - ubuntu-18.04
+          - ubuntu-latest
           - macos-latest
         python:
           - 3.7


### PR DESCRIPTION
The affected workflows currently use ubuntu-18.04, [which is deprecated](https://github.com/actions/runner-images/issues/6002).