### PR TITLE
Use GitHub for Flake8 pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     rev: v2.2.1
     hooks:
     -   id: codespell
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8


### PR DESCRIPTION
Flake8 migrated to GitHub, see https://flake8.pycqa.org/en/latest/release-notes/4.0.0.html.