### PR TITLE
added funderidtype and support for funder and sponsor roles to datacite metadata

### DIFF
--- a/dandischema/datacite.py
+++ b/dandischema/datacite.py
@@ -126,7 +126,10 @@ def to_datacite(
                 dict_fund["awardNumber"] = contr_el.awardNumber
             attributes.setdefault("fundingReferences", []).append(dict_fund)
             # if no more roles, it shouldn't be added to creators or contributors
-            contr_el.roleName.remove(RoleType("dcite:Sponsor"))
+            if RoleType("dcite:Sponsor") in contr_el.roleName:
+                contr_el.roleName.remove(RoleType("dcite:Sponsor"))
+            if RoleType("dcite:Funder") in contr_el.roleName:
+                contr_el.roleName.remove(RoleType("dcite:Funder"))
             if not contr_el.roleName:
                 continue
 

--- a/dandischema/datacite.py
+++ b/dandischema/datacite.py
@@ -115,6 +115,10 @@ def to_datacite(
             dict_fund = {"funderName": contr_el.name}
             if contr_el.identifier:
                 dict_fund["funderIdentifier"] = contr_el.identifier
+                funderidtype = "Other"
+                if "ror.org" in contr_el.identifier:
+                    funderidtype = "ROR"
+                dict_fund["funderIdentifierType"] = funderidtype
             if contr_el.awardNumber:
                 dict_fund["awardNumber"] = contr_el.awardNumber
             attributes.setdefault("fundingReferences", []).append(dict_fund)

--- a/dandischema/datacite.py
+++ b/dandischema/datacite.py
@@ -110,7 +110,7 @@ def to_datacite(
     contributors = []
     creators = []
     for contr_el in meta.contributor:
-        if contr_el.roleName and RoleType("dcite:Sponsor") in contr_el.roleName:
+        if contr_el.roleName and (RoleType("dcite:Sponsor") in contr_el.roleName or RoleType("dcite:Funder") in contr_el.roleName):
             # no info about "funderIdentifierType", "awardUri", "awardTitle"
             dict_fund = {"funderName": contr_el.name}
             if contr_el.identifier:

--- a/dandischema/datacite.py
+++ b/dandischema/datacite.py
@@ -110,7 +110,10 @@ def to_datacite(
     contributors = []
     creators = []
     for contr_el in meta.contributor:
-        if contr_el.roleName and (RoleType("dcite:Sponsor") in contr_el.roleName or RoleType("dcite:Funder") in contr_el.roleName):
+        if contr_el.roleName and (
+            RoleType("dcite:Sponsor") in contr_el.roleName
+            or RoleType("dcite:Funder") in contr_el.roleName
+        ):
             # no info about "funderIdentifierType", "awardUri", "awardTitle"
             dict_fund = {"funderName": contr_el.name}
             if contr_el.identifier:

--- a/dandischema/tests/test_datacite.py
+++ b/dandischema/tests/test_datacite.py
@@ -223,6 +223,29 @@ def test_datacite(dandi_id: str, schema: Any) -> None:
                 "fundingReferences": (1, {"funderName": "B_last, B_first"}),
             },
         ),
+        # Add a sponsor with an identifier
+        (
+            {
+                "contributor": [
+                    {
+                        "name": "A_last, A_first",
+                        "roleName": [RoleType("dcite:ContactPerson")],
+                    },
+                    {
+                        "name": "B_last, B_first",
+                        "identifier": "0000-0001-0000-0000",
+                        "roleName": [RoleType("dcite:Sponsor")],
+                    },
+                ],
+            },
+            {
+                "creators": (1, {"name": "A_last, A_first"}),
+                "fundingReferences": (1, {"funderName": "B_last, B_first", 
+                                          "funderIdentifier": "0000-0001-0000-0000",
+                                          "funderIdentifierType": "Other",
+                                         }),
+            },
+        ),
         # additional contributor with 2 roles: Author and Software (doesn't exist in datacite)
         # the person should be in creators and contributors (with contributorType Other)
         # Adding Orcid ID to the identifier to one of the contributors

--- a/dandischema/tests/test_datacite.py
+++ b/dandischema/tests/test_datacite.py
@@ -240,10 +240,14 @@ def test_datacite(dandi_id: str, schema: Any) -> None:
             },
             {
                 "creators": (1, {"name": "A_last, A_first"}),
-                "fundingReferences": (1, {"funderName": "B_last, B_first", 
-                                          "funderIdentifier": "0000-0001-0000-0000",
-                                          "funderIdentifierType": "Other",
-                                         }),
+                "fundingReferences": (
+                    1,
+                    {
+                        "funderName": "B_last, B_first",
+                        "funderIdentifier": "0000-0001-0000-0000",
+                        "funderIdentifierType": "Other",
+                    },
+                ),
             },
         ),
         # additional contributor with 2 roles: Author and Software (doesn't exist in datacite)

--- a/dandischema/tests/test_datacite.py
+++ b/dandischema/tests/test_datacite.py
@@ -250,6 +250,33 @@ def test_datacite(dandi_id: str, schema: Any) -> None:
                 ),
             },
         ),
+        # should also work with Funder role
+        (
+            {
+                "contributor": [
+                    {
+                        "name": "A_last, A_first",
+                        "roleName": [RoleType("dcite:ContactPerson")],
+                    },
+                    {
+                        "name": "B_last, B_first",
+                        "identifier": "0000-0001-0000-0000",
+                        "roleName": [RoleType("dcite:Funder")],
+                    },
+                ],
+            },
+            {
+                "creators": (1, {"name": "A_last, A_first"}),
+                "fundingReferences": (
+                    1,
+                    {
+                        "funderName": "B_last, B_first",
+                        "funderIdentifier": "0000-0001-0000-0000",
+                        "funderIdentifierType": "Other",
+                    },
+                ),
+            },
+        ),
         # additional contributor with 2 roles: Author and Software (doesn't exist in datacite)
         # the person should be in creators and contributors (with contributorType Other)
         # Adding Orcid ID to the identifier to one of the contributors


### PR DESCRIPTION
closes #168 

- added funderidtype
- added support for funders and sponsors

according to @djarecka's test the current release mints a doi for the failing metadata schema on dandiarchive, so unsure what the exact issue was. nonetheless this update should be used moving forward since people use funder/sponsor synonymously in dandiset metadata.