### PR TITLE
adding dcite:Funder to fundingReferences

### DIFF
--- a/dandischema/datacite.py
+++ b/dandischema/datacite.py
@@ -110,7 +110,7 @@ def to_datacite(
     contributors = []
     creators = []
     for contr_el in meta.contributor:
-        if contr_el.roleName and RoleType("dcite:Sponsor") in contr_el.roleName:
+        if contr_el.roleName and (RoleType("dcite:Sponsor") in contr_el.roleName or RoleType("dcite:Funder") in contr_el.roleName):
             # no info about "funderIdentifierType", "awardUri", "awardTitle"
             dict_fund = {"funderName": contr_el.name}
             if contr_el.identifier:
@@ -119,7 +119,11 @@ def to_datacite(
                 dict_fund["awardNumber"] = contr_el.awardNumber
             attributes.setdefault("fundingReferences", []).append(dict_fund)
             # if no more roles, it shouldn't be added to creators or contributors
-            contr_el.roleName.remove(RoleType("dcite:Sponsor"))
+            if RoleType("dcite:Sponsor") in contr_el.roleName:
+                contr_el.roleName.remove(RoleType("dcite:Sponsor"))
+            if RoleType("dcite:Funder") in contr_el.roleName:
+                contr_el.roleName.remove(RoleType("dcite:Funder"))
+
             if not contr_el.roleName:
                 continue
 

--- a/dandischema/datacite.py
+++ b/dandischema/datacite.py
@@ -110,7 +110,10 @@ def to_datacite(
     contributors = []
     creators = []
     for contr_el in meta.contributor:
-        if contr_el.roleName and (RoleType("dcite:Sponsor") in contr_el.roleName or RoleType("dcite:Funder") in contr_el.roleName):
+        if contr_el.roleName and (
+            RoleType("dcite:Sponsor") in contr_el.roleName
+            or RoleType("dcite:Funder") in contr_el.roleName
+        ):
             # no info about "funderIdentifierType", "awardUri", "awardTitle"
             dict_fund = {"funderName": contr_el.name}
             if contr_el.identifier:

--- a/dandischema/tests/test_datacite.py
+++ b/dandischema/tests/test_datacite.py
@@ -225,22 +225,22 @@ def test_datacite(dandi_id: str, schema: Any) -> None:
         ),
         # additional contributor with dandi:Funder, fundingReferences should be also created (as for Sponsor)
         (
-                {
-                    "contributor": [
-                        {
-                            "name": "A_last, A_first",
-                            "roleName": [RoleType("dcite:ContactPerson")],
-                        },
-                        {
-                            "name": "B_last, B_first",
-                            "roleName": [RoleType("dcite:Funder")],
-                        },
-                    ],
-                },
-                {
-                    "creators": (1, {"name": "A_last, A_first"}),
-                    "fundingReferences": (1, {"funderName": "B_last, B_first"}),
-                },
+            {
+                "contributor": [
+                    {
+                        "name": "A_last, A_first",
+                        "roleName": [RoleType("dcite:ContactPerson")],
+                    },
+                    {
+                        "name": "B_last, B_first",
+                        "roleName": [RoleType("dcite:Funder")],
+                    },
+                ],
+            },
+            {
+                "creators": (1, {"name": "A_last, A_first"}),
+                "fundingReferences": (1, {"funderName": "B_last, B_first"}),
+            },
         ),
         # additional contributor with 2 roles: Author and Software (doesn't exist in datacite)
         # the person should be in creators and contributors (with contributorType Other)

--- a/dandischema/tests/test_datacite.py
+++ b/dandischema/tests/test_datacite.py
@@ -223,6 +223,25 @@ def test_datacite(dandi_id: str, schema: Any) -> None:
                 "fundingReferences": (1, {"funderName": "B_last, B_first"}),
             },
         ),
+        # additional contributor with dandi:Funder, fundingReferences should be also created (as for Sponsor)
+        (
+                {
+                    "contributor": [
+                        {
+                            "name": "A_last, A_first",
+                            "roleName": [RoleType("dcite:ContactPerson")],
+                        },
+                        {
+                            "name": "B_last, B_first",
+                            "roleName": [RoleType("dcite:Funder")],
+                        },
+                    ],
+                },
+                {
+                    "creators": (1, {"name": "A_last, A_first"}),
+                    "fundingReferences": (1, {"funderName": "B_last, B_first"}),
+                },
+        ),
         # additional contributor with 2 roles: Author and Software (doesn't exist in datacite)
         # the person should be in creators and contributors (with contributorType Other)
         # Adding Orcid ID to the identifier to one of the contributors


### PR DESCRIPTION
treating `dcite:Funder` in the same way as `dcite:Sponsor` and adding it to the `fundingReferences`

fixes #168 