### PR TITLE
Restrict pydantic requirement to < 2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ project_urls =
 python_requires = >=3.7
 install_requires =
     jsonschema[format]
-    pydantic[email] >= 1.8.1
+    pydantic[email] >= 1.8.1, < 2.0
     typing_extensions;  python_version < "3.8"
     requests
 zip_safe = False


### PR DESCRIPTION
We can update the code to use pydantic 2.0 after it comes out.

See #176.