### PR TITLE
Test against pydantic 2.0 prereleases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,11 @@ jobs:
           - 3.9
           - '3.10'
           - '3.11'
+        toxenv: [py]
+        include:
+          - os: ubuntu-latest
+            python: 3.7
+            toxenv: dev
     steps:
     - name: Set up environment
       uses: actions/checkout@v3
@@ -44,7 +49,7 @@ jobs:
         python -m pip install --upgrade tox
 
     - name: Run all tests
-      run: tox -e py -- -s --cov-report=xml
+      run: tox -e ${{ matrix.toxenv }} -- -s --cov-report=xml
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -7,6 +7,12 @@ on:
 jobs:
   typing:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testenv:
+          - typing
+          - devtyping
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -24,4 +30,4 @@ jobs:
           python -m pip install --upgrade tox
 
       - name: Run type checker
-        run: tox -e typing
+        run: tox -e ${{ matrix.testenv }}

--- a/dandischema/digests/zarr.py
+++ b/dandischema/digests/zarr.py
@@ -5,7 +5,10 @@ import hashlib
 import re
 from typing import Dict, List, Optional, Tuple
 
-import pydantic
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 
 """Passed to the json() method of pydantic models for serialization."""
 ENCODING_KWARGS = {"separators": (",", ":")}

--- a/dandischema/metadata.py
+++ b/dandischema/metadata.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, TypeVar, Union, cast
 
 import jsonschema
-import pydantic
 import requests
 
 from .consts import (
@@ -17,6 +16,11 @@ from .exceptions import JsonschemaValidationError, PydanticValidationError
 from . import models
 from .utils import _ensure_newline, version2tuple
 
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
+
 schema_map = {
     "Dandiset": "dandiset.json",
     "PublishedDandiset": "published-dandiset.json",
@@ -26,8 +30,6 @@ schema_map = {
 
 
 def generate_context() -> dict:
-    import pydantic
-
     field_preamble = {
         "@version": 1.1,
         "dandi": "http://schema.dandiarchive.org/",

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -7,17 +7,30 @@ import re
 import sys
 from typing import Any, Dict, List, Optional, Sequence, Type, TypeVar, Union, cast
 
-from pydantic import (
-    UUID4,
-    AnyHttpUrl,
-    BaseModel,
-    ByteSize,
-    EmailStr,
-    Field,
-    parse_obj_as,
-    root_validator,
-    validator,
-)
+try:
+    from pydantic.v1 import (
+        UUID4,
+        AnyHttpUrl,
+        BaseModel,
+        ByteSize,
+        EmailStr,
+        Field,
+        parse_obj_as,
+        root_validator,
+        validator,
+    )
+except ImportError:
+    from pydantic import (
+        UUID4,
+        AnyHttpUrl,
+        BaseModel,
+        ByteSize,
+        EmailStr,
+        Field,
+        parse_obj_as,
+        root_validator,
+        validator,
+    )
 
 from .consts import DANDI_SCHEMA_VERSION
 from .digests.dandietag import DandiETag

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -4,8 +4,6 @@ import json
 import sys
 from typing import Any, Dict, List, Optional, Type, Union
 
-import pydantic
-from pydantic import Field, ValidationError
 import pytest
 
 from .test_datacite import _basic_publishmeta
@@ -33,6 +31,11 @@ from ..models import (
     Resource,
     RoleType,
 )
+
+try:
+    import pydantic.v1 as pydantic
+except ImportError:
+    import pydantic
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal
@@ -405,7 +408,7 @@ def test_dantimeta_1() -> None:
 
     # should work for Dandiset but PublishedDandiset should raise an error
     Dandiset(**meta_dict)
-    with pytest.raises(ValidationError) as exc:
+    with pytest.raises(pydantic.ValidationError) as exc:
         PublishedDandiset(**meta_dict)
 
     error_msgs = [
@@ -557,7 +560,7 @@ def test_properties_mismatch() -> None:
 def test_schemakey_roundtrip() -> None:
     class TempKlass(DandiBaseModel):
         contributor: Optional[List[Union[Organization, Person]]]
-        schemaKey: Literal["TempKlass"] = Field("TempKlass", readOnly=True)
+        schemaKey: Literal["TempKlass"] = pydantic.Field("TempKlass", readOnly=True)
 
     contributor = [
         {
@@ -591,7 +594,7 @@ def test_schemakey_roundtrip() -> None:
 def test_name_regex(name: str) -> None:
     class TempKlass(DandiBaseModel):
         contributor: Person
-        schemaKey: Literal["TempKlass"] = Field("TempKlass", readOnly=True)
+        schemaKey: Literal["TempKlass"] = pydantic.Field("TempKlass", readOnly=True)
 
     contributor = {
         "name": name,

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
 
 [testenv:dev]
 commands_pre =
-    pip install --pre --upgrade --no-warn-conflicts pydantic
+    pip install --pre --upgrade --no-warn-conflicts git+https://github.com/pydantic/pydantic
 
 [testenv:lint]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,10 @@ passenv =
 commands =
     pytest -v {posargs} dandischema
 
+[testenv:dev]
+commands_pre =
+    pip install --pre --upgrade --no-warn-conflicts pydantic
+
 [testenv:lint]
 skip_install = true
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,12 @@ extras = test
 commands =
     mypy dandischema
 
+[testenv:devtyping]
+deps = {[testenv:typing]deps}
+extras = {[testenv:typing]extras}
+commands_pre = {[testenv:dev]commands_pre}
+commands = {[testenv:typing]commands}
+
 [pytest]
 addopts = --cov=dandischema --tb=short --durations=10
 filterwarnings = error


### PR DESCRIPTION
Part of #176.

Note that we cannot make the code compatible with both pydantic 1.x and 2.x, as [all pydantic instance methods have been renamed](https://docs.pydantic.dev/blog/pydantic-v2/#model-namespace-cleanup).