### PR TITLE
BF: make code not puke if there is no encodingFormat in asset metadata

### DIFF
--- a/dandischema/metadata.py
+++ b/dandischema/metadata.py
@@ -322,7 +322,7 @@ def _add_asset_to_stats(assetmeta: Dict[str, Any], stats: _stats_type) -> None:
                 stats["tissuesample"].append(sample)
 
     stats["dataStandard"] = stats.get("dataStandard", [])
-    if "nwb" in assetmeta["encodingFormat"]:
+    if "nwb" in assetmeta.get("encodingFormat", ""):
         if models.nwb_standard not in stats["dataStandard"]:
             stats["dataStandard"].append(models.nwb_standard)
     # TODO: RF assumption that any .json implies BIDS


### PR DESCRIPTION
Although it is not clear how that can happen since it is not optional, worth 

- [ ] checking which assets lack it and why

Closes #183