### PR TITLE
Unpin versioningit version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 # Setuptools version should match setup.py; wheel because pip will insert it noisily
-requires = ["setuptools >= 42.0.0", "versioningit ~= 0.3.0", "wheel"]
+requires = ["setuptools >= 42.0.0", "versioningit", "wheel"]
 build-backend = 'setuptools.build_meta'
 
 [tool.versioningit]
@@ -11,9 +11,9 @@ exclude = ["schema-*"]
 
 [tool.versioningit.format]
 # Same format as versioneer
-distance = "{version}+{distance}.{vcs}{rev}"
-dirty = "{version}+{distance}.{vcs}{rev}.dirty"
-distance-dirty = "{version}+{distance}.{vcs}{rev}.dirty"
+distance = "{base_version}+{distance}.{vcs}{rev}"
+dirty = "{base_version}+{distance}.{vcs}{rev}.dirty"
+distance-dirty = "{base_version}+{distance}.{vcs}{rev}.dirty"
 
 [tool.versioningit.write]
 file = "dandischema/_version.py"


### PR DESCRIPTION
`versioningit` is not meant to have an upper version bound (unless you're using custom methods, which you're not), as restricting it cuts you out of bugfixes & new features.  Also, the `{version}` field in the "format" table is now deprecated in favor of `{base_version}` (though `{version}` will continue to work).