### PR TITLE
Rerun failing `test_dandimeta_datacite` tests

### DIFF
--- a/dandischema/tests/test_datacite.py
+++ b/dandischema/tests/test_datacite.py
@@ -156,6 +156,7 @@ def test_datacite(dandi_id: str, schema: Any) -> None:
     datacite_post(datacite, meta.doi)
 
 
+@pytest.mark.flaky(reruns=5, reruns_delay=5, only_rerun="HTTPError")
 @skipif_no_network
 @pytest.mark.parametrize(
     "additional_meta, datacite_checks",

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ test =
     mypy
     pytest
     pytest-cov
+    pytest-rerunfailures
 all =
     #%(doc)s
     %(style)s


### PR DESCRIPTION
It frequently happens that a CI run fails because one instance of `test_dandimeta_datacite` on one platform got a 422 error.  The evidence suggests that this a problem on datacite's end, so this PR causes the test to simply be retried a few times until it succeeds.