### PR TITLE
Allow dictionary representation of `Dandiset` to have extra attributes

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -1,4 +1,4 @@
-DANDI_SCHEMA_VERSION = "0.6.5"
+DANDI_SCHEMA_VERSION = "0.6.6"
 ALLOWED_INPUT_SCHEMAS = [
     "0.4.4",
     "0.5.1",
@@ -8,6 +8,7 @@ ALLOWED_INPUT_SCHEMAS = [
     "0.6.2",
     "0.6.3",
     "0.6.4",
+    "0.6.5",
 ]
 
 # ATM we allow only for a single target version which is current

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -9,6 +9,7 @@ from pydantic import (
     UUID4,
     AnyHttpUrl,
     BaseModel,
+    ConfigDict,
     EmailStr,
     Field,
     GetJsonSchemaHandler,
@@ -1401,6 +1402,8 @@ class CommonModel(DandiBaseModel):
 
 class Dandiset(CommonModel):
     """A body of structured information describing a DANDI dataset."""
+
+    model_config = ConfigDict(extra="allow")
 
     @field_validator("contributor")
     @classmethod


### PR DESCRIPTION
This PR allows the dictionary representation of `Dandiset` to have extra attributes.

ATM, packages such as [dandi-archive](https://github.com/dandi/dandi-archive) construct `Dandiset` objects using `Dandiset.model_construct()` to allow extra attributes to be passed to the resulting `Dandiset` objects. While extra attributes can be passed to the resulting `Dandiset` objects this way, the dictionary representations of these `Dandiset` objects will not contain the extra attributes unless `Dandiset` is explicitly configured to allow extra attributes. 

[dandi-archive](https://github.com/dandi/dandi-archive) requires extra attributes passed in constructing a `Dandiset` object to be present in the dictionary representation of the object. This change in this PR explicitly configures `Dandiset` to allow extra attributes to meet this requirement, and meeting this requirement will eliminate some of the failures encountered in https://github.com/dandi/dandi-archive/pull/1823.

Please note, the change in this PR will modify the JSON schemata for `Dandiset` and `PublishedDandiset` slightly. Both schemata will contain the additional key of `"additionalProperties"` with the value of `true`. Please consider increase the version number of the JSON schemas to 0.6.6.

Note: This PR is a follow up to #203 to make a new version of dandi-schema with Pydantic 2.0 working for dandi-archive.