### PR TITLE
Remove unneeded mark to fixture

### DIFF
--- a/dandischema/tests/test_datacite.py
+++ b/dandischema/tests/test_datacite.py
@@ -45,7 +45,6 @@ def _clean_doi(doi: str) -> None:
     )
 
 
-@skipif_no_network
 @pytest.fixture(scope="module")
 def schema() -> Any:
     return _get_datacite_schema()


### PR DESCRIPTION
Applying a mark to a fixture function never had any affect. It now issues a warning in Pytest V8 and will raise an error in the future version of Pytest. For details, please check out https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function.

Merging this PR is necessary for future PRs to pass the needed tests.