### PR TITLE
Customize JSON schema generation for `Literal` fields of Pydantic models

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -1,4 +1,4 @@
-DANDI_SCHEMA_VERSION = "0.6.6"
+DANDI_SCHEMA_VERSION = "0.6.7"
 ALLOWED_INPUT_SCHEMAS = [
     "0.4.4",
     "0.5.1",
@@ -9,6 +9,7 @@ ALLOWED_INPUT_SCHEMAS = [
     "0.6.3",
     "0.6.4",
     "0.6.5",
+    "0.6.6",
 ]
 
 # ATM we allow only for a single target version which is current

--- a/dandischema/utils.py
+++ b/dandischema/utils.py
@@ -77,6 +77,32 @@ class TransitionalGenerateJsonSchema(GenerateJsonSchema):
 
         return self.generate_inner(schema["schema"])
 
+    def literal_schema(self, schema: core_schema.LiteralSchema) -> JsonSchemaValue:
+        # Override the default behavior for handling a core schema that represents a
+        # `Literal`. With this override, `Literal` types of a single value will also
+        # have a JSON schema that has a `"type"` key with the value of the type of the
+        # single value. This behavior is the one exhibited in Pydantic V1.
+
+        json_schema = super().literal_schema(schema)
+
+        if "const" in json_schema:
+            t = type(json_schema["const"])
+
+            if t is type(None):
+                json_schema["type"] = "null"
+            elif t is str:
+                json_schema["type"] = "string"
+            elif t is int:
+                json_schema["type"] = "integer"
+            elif t is float:
+                json_schema["type"] = "number"
+            elif t is bool:
+                json_schema["type"] = "boolean"
+            elif t is list:
+                json_schema["type"] = "array"
+
+        return json_schema
+
 
 def strip_top_level_optional(type_: Any) -> Any:
     """


### PR DESCRIPTION
This PR adds customization to the generation of JSON schema for the fields of Pydantic models that are of `Literal` type. Basically, this customization ensures that the JSON schema for a `Literal` field of a Pydantic model has a `type` key. 

This customization revert change 3v entailed by Pydantic V2 listed in the top post of #203. Hopefully, it will also satisfy @satra's request at https://github.com/dandi/dandi-archive/commit/b3db2310632782ccac935b3a680818fe765ae8e7#commitcomment-138484018.