### PR TITLE
Include additional valid LicenseType enums for downstream applications

### DIFF
--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -118,6 +118,7 @@ class IdentifierType(Enum):
 
 class LicenseType(Enum):
     """An enumeration of supported licenses"""
+
     # DANDI-specific -- supported within https://spdx.org/licenses/
     CC0_10 = "spdx:CC0-1.0"
     CC_BY_40 = "spdx:CC-BY-4.0"
@@ -1048,9 +1049,9 @@ class Activity(DandiBaseModel):
 
     # isPartOf: Optional["Activity"] = Field(None, json_schema_extra={"nskey": "schema"})
     # hasPart: Optional["Activity"] = Field(None, json_schema_extra={"nskey": "schema"})
-    wasAssociatedWith: Optional[List[Union[Person, Organization, Software, Agent]]] = (
-        Field(None, json_schema_extra={"nskey": "prov"})
-    )
+    wasAssociatedWith: Optional[
+        List[Union[Person, Organization, Software, Agent]]
+    ] = Field(None, json_schema_extra={"nskey": "prov"})
     used: Optional[List[Equipment]] = Field(
         None,
         description="A listing of equipment used for the activity.",

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -118,9 +118,12 @@ class IdentifierType(Enum):
 
 class LicenseType(Enum):
     """An enumeration of supported licenses"""
-
+    # DANDI-specific -- supported within https://spdx.org/licenses/
     CC0_10 = "spdx:CC0-1.0"
     CC_BY_40 = "spdx:CC-BY-4.0"
+    # LINC Brain, other specific
+    UNLICENSED = "unlicensed"
+    PRIVATE = "private"
 
 
 class RelationType(Enum):

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -321,6 +321,8 @@ def test_asset_digest() -> None:
             {
                 "CC0_10": "spdx:CC0-1.0",
                 "CC_BY_40": "spdx:CC-BY-4.0",
+                "PRIVATE": "private",
+                "UNLICENSED": "unlicensed",
             },
         ),
         (


### PR DESCRIPTION
The current list of LicenseType enumerations assumes that all datasets fall within the two Creative Commons license. 

The goal of this PR is to expand the available options so that projects like `linc-archive` can pass validation via `dandischema` 

Cc @kabilar 