### PR TITLE
Add validator to ensure a contact person has email provided

### DIFF
--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import date, datetime
 from enum import Enum
 import os
@@ -844,6 +846,16 @@ class Contributor(DandiBaseModel):
     schemaKey: Literal["Contributor", "Organization", "Person"] = Field(
         "Contributor", validate_default=True, json_schema_extra={"readOnly": True}
     )
+
+    @model_validator(mode="after")
+    def ensure_contact_person_has_email(self) -> Contributor:
+        role_names = self.roleName
+
+        if role_names is not None and RoleType.ContactPerson in role_names:
+            if self.email is None:
+                raise ValueError("Contact person must have an email address.")
+
+        return self
 
 
 class Organization(Contributor):

--- a/dandischema/tests/test_datacite.py
+++ b/dandischema/tests/test_datacite.py
@@ -70,6 +70,7 @@ def metadata_basic() -> Dict[str, Any]:
         "contributor": [
             {
                 "name": "A_last, A_first",
+                "email": "nemo@example.com",
                 "roleName": [RoleType("dcite:ContactPerson")],
             }
         ],

--- a/dandischema/tests/test_metadata.py
+++ b/dandischema/tests/test_metadata.py
@@ -156,6 +156,7 @@ def test_mismatch_key(schema_version: str, schema_key: str) -> None:
                     {
                         "schemaKey": "Person",
                         "name": "Last, first",
+                        "email": "nobody@example.com",
                         "roleName": ["dcite:ContactPerson"],
                     }
                 ],

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -694,32 +694,26 @@ def test_embargoedaccess() -> None:
     )
 
 
-def _non_contact_person_roles_args() -> List[List[RoleType]]:
-    """
-    Return a list of role lists that each do not contain the role of a contact person
-    """
-    return [[], [RoleType.Author, RoleType.DataCurator], [RoleType.Funder]]
+_NON_CONTACT_PERSON_ROLES_ARGS = [
+    [],
+    [RoleType.Author, RoleType.DataCurator],
+    [RoleType.Funder],
+]
 
-
-def _contact_person_roles_args() -> List[List[RoleType]]:
-    """
-    Return a list of role lists that each contains the role of a contact person
-    """
-    return [
-        role_lst + [RoleType.ContactPerson]
-        for role_lst in _non_contact_person_roles_args()
-    ]
+_CONTACT_PERSON_ROLES_ARGS = [
+    role_lst + [RoleType.ContactPerson] for role_lst in _NON_CONTACT_PERSON_ROLES_ARGS
+]
 
 
 class TestContributor:
-    @pytest.mark.parametrize("roles", _contact_person_roles_args())
+    @pytest.mark.parametrize("roles", _CONTACT_PERSON_ROLES_ARGS)
     def test_contact_person_with_email(self, roles: List[RoleType]) -> None:
         """
         Test creating a `Contributor` instance as a contact person with an email
         """
         Contributor(email="nemo@dandiarchive.org", roleName=roles)
 
-    @pytest.mark.parametrize("roles", _contact_person_roles_args())
+    @pytest.mark.parametrize("roles", _CONTACT_PERSON_ROLES_ARGS)
     def test_contact_person_without_email(self, roles: List[RoleType]) -> None:
         """
         Test creating a `Contributor` instance as a contact person without an email
@@ -729,14 +723,14 @@ class TestContributor:
         ):
             Contributor(roleName=roles)
 
-    @pytest.mark.parametrize("roles", _non_contact_person_roles_args())
+    @pytest.mark.parametrize("roles", _NON_CONTACT_PERSON_ROLES_ARGS)
     def test_non_contact_person_with_email(self, roles: List[RoleType]) -> None:
         """
         Test creating a `Contributor` instance as a non-contact person with an email
         """
         Contributor(email="nemo@dandiarchive.org", roleName=roles)
 
-    @pytest.mark.parametrize("roles", _non_contact_person_roles_args())
+    @pytest.mark.parametrize("roles", _NON_CONTACT_PERSON_ROLES_ARGS)
     def test_non_contact_person_without_email(self, roles: List[RoleType]) -> None:
         """
         Test creating a `Contributor` instance as a non-contact person without an email

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -717,6 +717,13 @@ class TestContributor:
         ):
             Contributor(roleName=roles)
 
+    @pytest.mark.parametrize("roles", _NON_CONTACT_PERSON_ROLES_ARGS)
+    def test_non_contact_person_without_email(self, roles: List[RoleType]) -> None:
+        """
+        Test creating a `Contributor` instance as a non-contact person without an email
+        """
+        Contributor(roleName=roles)
+
     @pytest.mark.parametrize(
         "roles", _NON_CONTACT_PERSON_ROLES_ARGS + _CONTACT_PERSON_ROLES_ARGS
     )
@@ -725,10 +732,3 @@ class TestContributor:
         Test creating a `Contributor` instance with an email
         """
         Contributor(email="nemo@dandiarchive.org", roleName=roles)
-
-    @pytest.mark.parametrize("roles", _NON_CONTACT_PERSON_ROLES_ARGS)
-    def test_non_contact_person_without_email(self, roles: List[RoleType]) -> None:
-        """
-        Test creating a `Contributor` instance as a non-contact person without an email
-        """
-        Contributor(roleName=roles)

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -18,6 +18,7 @@ from ..models import (
     Asset,
     BaseType,
     CommonModel,
+    Contributor,
     DandiBaseModel,
     Dandiset,
     DigestType,
@@ -691,3 +692,53 @@ def test_embargoedaccess() -> None:
             )
         ]
     )
+
+
+def _non_contact_person_roles_args() -> List[List[RoleType]]:
+    """
+    Return a list of role lists that each do not contain the role of a contact person
+    """
+    return [[], [RoleType.Author, RoleType.DataCurator], [RoleType.Funder]]
+
+
+def _contact_person_roles_args() -> List[List[RoleType]]:
+    """
+    Return a list of role lists that each contains the role of a contact person
+    """
+    return [
+        role_lst + [RoleType.ContactPerson]
+        for role_lst in _non_contact_person_roles_args()
+    ]
+
+
+class TestContributor:
+    @pytest.mark.parametrize("roles", _contact_person_roles_args())
+    def test_contact_person_with_email(self, roles: List[RoleType]) -> None:
+        """
+        Test creating a `Contributor` instance as a contact person with an email
+        """
+        Contributor(email="nemo@dandiarchive.org", roleName=roles)
+
+    @pytest.mark.parametrize("roles", _contact_person_roles_args())
+    def test_contact_person_without_email(self, roles: List[RoleType]) -> None:
+        """
+        Test creating a `Contributor` instance as a contact person without an email
+        """
+        with pytest.raises(
+            pydantic.ValidationError, match="Contact person must have an email address"
+        ):
+            Contributor(roleName=roles)
+
+    @pytest.mark.parametrize("roles", _non_contact_person_roles_args())
+    def test_non_contact_person_with_email(self, roles: List[RoleType]) -> None:
+        """
+        Test creating a `Contributor` instance as a non-contact person with an email
+        """
+        Contributor(email="nemo@dandiarchive.org", roleName=roles)
+
+    @pytest.mark.parametrize("roles", _non_contact_person_roles_args())
+    def test_non_contact_person_without_email(self, roles: List[RoleType]) -> None:
+        """
+        Test creating a `Contributor` instance as a non-contact person without an email
+        """
+        Contributor(roleName=roles)

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -706,12 +706,6 @@ _CONTACT_PERSON_ROLES_ARGS = [
 
 
 class TestContributor:
-    @pytest.mark.parametrize("roles", _CONTACT_PERSON_ROLES_ARGS)
-    def test_contact_person_with_email(self, roles: List[RoleType]) -> None:
-        """
-        Test creating a `Contributor` instance as a contact person with an email
-        """
-        Contributor(email="nemo@dandiarchive.org", roleName=roles)
 
     @pytest.mark.parametrize("roles", _CONTACT_PERSON_ROLES_ARGS)
     def test_contact_person_without_email(self, roles: List[RoleType]) -> None:
@@ -723,10 +717,12 @@ class TestContributor:
         ):
             Contributor(roleName=roles)
 
-    @pytest.mark.parametrize("roles", _NON_CONTACT_PERSON_ROLES_ARGS)
-    def test_non_contact_person_with_email(self, roles: List[RoleType]) -> None:
+    @pytest.mark.parametrize(
+        "roles", _NON_CONTACT_PERSON_ROLES_ARGS + _CONTACT_PERSON_ROLES_ARGS
+    )
+    def test_with_email(self, roles: List[RoleType]) -> None:
         """
-        Test creating a `Contributor` instance as a non-contact person with an email
+        Test creating a `Contributor` instance with an email
         """
         Contributor(email="nemo@dandiarchive.org", roleName=roles)
 

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -378,6 +378,7 @@ def test_dantimeta_1() -> None:
         "contributor": [
             {
                 "name": "last name, first name",
+                "email": "someone@dandiarchive.org",
                 "roleName": [RoleType("dcite:ContactPerson")],
             }
         ],
@@ -592,6 +593,7 @@ def test_schemakey_roundtrip() -> None:
         },
         {
             "name": "last2, first2",
+            "email": "nospam@dandiarchive.org",
             "roleName": ["dcite:ContactPerson"],
             "schemaKey": "Person",
             "affiliation": [],

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -694,13 +694,13 @@ def test_embargoedaccess() -> None:
     )
 
 
-_NON_CONTACT_PERSON_ROLES_ARGS = [
+_NON_CONTACT_PERSON_ROLES_ARGS: List[List[RoleType]] = [
     [],
     [RoleType.Author, RoleType.DataCurator],
     [RoleType.Funder],
 ]
 
-_CONTACT_PERSON_ROLES_ARGS = [
+_CONTACT_PERSON_ROLES_ARGS: List[List[RoleType]] = [
     role_lst + [RoleType.ContactPerson] for role_lst in _NON_CONTACT_PERSON_ROLES_ARGS
 ]
 


### PR DESCRIPTION
This PR provides a model level validator to ensures that a contributor acting as a contact person has an email provided per request of https://github.com/dandi/dandi-schema/issues/189.

