### PR TITLE
GitHub tests.yml CI: explicitly specify macos-12 and use python 3.11 to test against dandi-cli

### DIFF
--- a/.github/workflows/test-dandi-cli.yml
+++ b/.github/workflows/test-dandi-cli.yml
@@ -25,10 +25,10 @@ jobs:
         python:
           # Use the only Python which is ATM also used by dandi-api
           # - 3.7
-          - 3.8
+          # - 3.8
           # - 3.9
           # - '3.10'
-          # - '3.11'
+          - '3.11'
         version:
           - master
           - release

--- a/.github/workflows/test-nonetwork.yml
+++ b/.github/workflows/test-nonetwork.yml
@@ -17,7 +17,7 @@ jobs:
         os:
           - windows-2019
           - ubuntu-latest
-          - macos-latest
+          - macos-12
         python:
           - 3.8
           - 3.9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         os:
           - windows-2019
           - ubuntu-latest
-          - macos-14
+          - macos-12
         python:
           - 3.8
           - 3.9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         os:
           - windows-2019
           - ubuntu-latest
-          - macos-latest
+          - macos-14
         python:
           - 3.8
           - 3.9


### PR DESCRIPTION
The arm64  one seems to lack pythons 3.8 and 3.9. Ref: https://github.com/dandi/dandi-schema/pull/236#issuecomment-2073369726