### PR TITLE
Draft: Relax timestamp timezone validation for startDate and endDate fields on NWB file formats

### DIFF
--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -1203,14 +1203,16 @@ class Activity(DandiBaseModel):
     _ldmeta = {"rdfs:subClassOf": ["prov:Activity", "schema:Thing"], "nskey": "dandi"}
 
     @field_validator('startDate', 'endDate', mode='before')
-    def parse_datetime(cls, value):
+    def parse_datetime(cls, value: Any) -> Optional[datetime]:
         if isinstance(value, str):
             try:
                 # Handles use-cases from .NWB file formats
                 return datetime.fromisoformat(value)
             except ValueError:
                 return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
-        return value
+        if isinstance(value, datetime):
+            return value
+        return None
 
 
 class Project(Activity):

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -1202,6 +1202,16 @@ class Activity(DandiBaseModel):
 
     _ldmeta = {"rdfs:subClassOf": ["prov:Activity", "schema:Thing"], "nskey": "dandi"}
 
+    @field_validator('startDate', 'endDate', mode='before')
+    def parse_datetime(cls, value):
+        if isinstance(value, str):
+            try:
+                # Handles use-cases from .NWB file formats
+                return datetime.fromisoformat(value)
+            except ValueError:
+                return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
+        return value
+
 
 class Project(Activity):
     name: str = Field(

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -1183,8 +1183,12 @@ class Activity(DandiBaseModel):
         description="The description of the activity.",
         json_schema_extra={"nskey": "schema"},
     )
-    startDate: Optional[Union[datetime, date]] = Field(None, json_schema_extra={"nskey": "schema"})
-    endDate: Optional[Union[datetime, date]] = Field(None, json_schema_extra={"nskey": "schema"})
+    startDate: Optional[Union[datetime, date]] = Field(
+        None, json_schema_extra={"nskey": "schema"}
+    )
+    endDate: Optional[Union[datetime, date]] = Field(
+        None, json_schema_extra={"nskey": "schema"}
+    )
 
     # isPartOf: Optional["Activity"] = Field(None, json_schema_extra={"nskey": "schema"})
     # hasPart: Optional["Activity"] = Field(None, json_schema_extra={"nskey": "schema"})

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -1183,8 +1183,8 @@ class Activity(DandiBaseModel):
         description="The description of the activity.",
         json_schema_extra={"nskey": "schema"},
     )
-    startDate: Optional[datetime] = Field(None, json_schema_extra={"nskey": "schema"})
-    endDate: Optional[datetime] = Field(None, json_schema_extra={"nskey": "schema"})
+    startDate: Optional[Union[datetime, date]] = Field(None, json_schema_extra={"nskey": "schema"})
+    endDate: Optional[Union[datetime, date]] = Field(None, json_schema_extra={"nskey": "schema"})
 
     # isPartOf: Optional["Activity"] = Field(None, json_schema_extra={"nskey": "schema"})
     # hasPart: Optional["Activity"] = Field(None, json_schema_extra={"nskey": "schema"})
@@ -1201,18 +1201,6 @@ class Activity(DandiBaseModel):
     )
 
     _ldmeta = {"rdfs:subClassOf": ["prov:Activity", "schema:Thing"], "nskey": "dandi"}
-
-    @field_validator('startDate', 'endDate', mode='before')
-    def parse_datetime(cls, value: Any) -> Optional[datetime]:
-        if isinstance(value, str):
-            try:
-                # Handles use-cases from .NWB file formats
-                return datetime.fromisoformat(value)
-            except ValueError:
-                return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
-        if isinstance(value, datetime):
-            return value
-        return None
 
 
 class Project(Activity):


### PR DESCRIPTION
Relates to https://github.com/dandi/dandi-archive/issues/1944

and changes made for NWB in https://github.com/NeurodataWithoutBorders/pynwb/pull/1886

Observed in failed dandiset validation in staging environment here: https://gui-staging.dandiarchive.org/dandiset/213840

Cc @candleindark @yarikoptic @satra @bendichter  