### PR TITLE
Move pattern specification for `BaseType.identifier` to the annotation for the `str` type

### DIFF
--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -15,6 +15,7 @@ from pydantic import (
     EmailStr,
     Field,
     GetJsonSchemaHandler,
+    StringConstraints,
     TypeAdapter,
     ValidationInfo,
     field_validator,
@@ -652,11 +653,20 @@ RRID = str
 class BaseType(DandiBaseModel):
     """Base class for enumerated types"""
 
-    identifier: Optional[Union[AnyHttpUrl, str]] = Field(
+    identifier: Optional[
+        Annotated[
+            Union[
+                AnyHttpUrl,
+                Annotated[
+                    str, StringConstraints(pattern=r"^[a-zA-Z0-9-]+:[a-zA-Z0-9-/\._]+$")
+                ],
+            ],
+            Field(union_mode="left_to_right"),
+        ]
+    ] = Field(
         None,
         description="The identifier can be any url or a compact URI, preferably"
         " supported by identifiers.org.",
-        pattern=r"^[a-zA-Z0-9-]+:[a-zA-Z0-9-/\._]+$",
         json_schema_extra={"nskey": "schema"},
     )
     name: Optional[str] = Field(


### PR DESCRIPTION
My guess of the intention for `BaseType.identifier` is an object either validates to an `AnyHttpUrl` or a `str` matching the pattern of `r"^[a-zA-Z0-9-]+:[a-zA-Z0-9-/\._]+$"`. If my guess is correct, the type annotation should be corrected to the proposed change in this PR.

The current type annotation of `BaseType.identifier` has problems exhibited by the `Foo.identifier` from the following example (`Baz.identifier` exhibits the solution proposed by this PR).

```py
from typing import Optional, Union
import json

from typing_extensions import Annotated

from pydantic import BaseModel, Field, AnyHttpUrl, StringConstraints, ValidationError

PATTERN = r"^[a-zA-Z0-9-]+:[a-zA-Z0-9-/\._]+$"


class Foo(BaseModel):
    identifier: Optional[Union[AnyHttpUrl, str]] = Field(None, pattern=PATTERN)


class Bar(BaseModel):
    identifier: Optional[
        Union[AnyHttpUrl, Annotated[str, StringConstraints(pattern=PATTERN)]]
    ] = None


class Baz(BaseModel):
    identifier: Optional[
        Annotated[
            Union[AnyHttpUrl, Annotated[str, StringConstraints(pattern=PATTERN)]],
            Field(union_mode="left_to_right"),
        ]
    ] = None

# Try inputting an AnyHttpUrl object
print("======= Interation 0 =======")
try:
    foo0 = Foo(identifier=AnyHttpUrl("https://example.com"))
except ValidationError as e:
    print(e)
    """
    1 validation error for Foo
    identifier
      Input should be a valid string [type=string_type, input_value=Url('https://example.com/'), input_type=Url]
        For further information visit https://errors.pydantic.dev/2.7/v/string_type
    """
else:
    raise RuntimeError("Expected a validation error")

bar0 = Bar(identifier=AnyHttpUrl("https://example.com"))
baz0 = Baz(identifier=AnyHttpUrl("https://example.com"))

# Try inputting a string object
print("\n======= Interation 1 =======")
try:
    foo1 = Foo(identifier="https://www.python.org/~guido?arg=1#frag")
except ValidationError as e:
    print(e)
    """
    1 validation error for Foo
    identifier
      String should match pattern '^[a-zA-Z0-9-]+:[a-zA-Z0-9-/\._]+$' [type=string_pattern_mismatch, input_value='https://www.python.org/~guido?arg=1#frag', input_type=str]
        For further information visit https://errors.pydantic.dev/2.7/v/string_pattern_mismatch
    """
else:
    raise RuntimeError("Expected a validation error")

bar1 = Bar(identifier="https://www.python.org/~guido?arg=1#frag")
print(f"type(bar1.identifier): {type(bar1.identifier)}")
"""type(bar1.identifier): <class 'pydantic_core._pydantic_core.Url'>"""

baz1 = Baz(identifier="https://www.python.org/~guido?arg=1#frag")
print(f"type(baz1.identifier): {type(baz1.identifier)}")
"""type(baz1.identifier): <class 'pydantic_core._pydantic_core.Url'>"""

# Try inputting a string object that are simple
print("\n======= Interation 2 =======")
bar2 = Bar(identifier="https://example.com")
print(f"type(bar2.identifier): {type(bar2.identifier)}")
"""type(bar2.identifier): <class 'str'>"""

baz2 = Baz(identifier="https://example.com")
print(f"type(baz2.identifier): {type(baz2.identifier)}")
"""type(baz2.identifier): <class 'pydantic_core._pydantic_core.Url'>"""
```

Essentially, the current annotation fails to validate any `AnyHttpUrl` object and any HTTP URL, as a `str`, that contains a special character.