### PR TITLE
Declare `typing_extensions` dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ install_requires =
     jsonschema[format]
     pydantic[email] ~= 2.4
     requests
+    typing_extensions; python_version < "3.9"
     zarr_checksum
 zip_safe = False
 packages = find_namespace:


### PR DESCRIPTION
Use of `typing_extensions` was reintroduced to the code in commit 0d381179 (#203), but `typing_extensions` was not added to the runtime requirements.  This PR fixes that.