### PR TITLE
Exclude tests from wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,10 +36,11 @@ install_requires =
     zarr_checksum
 zip_safe = False
 packages = find_namespace:
-include_package_data = True
+include_package_data = False
 
 [options.packages.find]
 include = dandischema*
+exclude = *tests*
 
 [options.extras_require]
 # I bet will come handy


### PR DESCRIPTION
It's generally not desired to install tests together with the module.
This change does just that and keeps everything else unchanged. Tests
are still included in the sdist.
