### PR TITLE
Upgrade to datacite v4.5 serialization from inveniosoftware

### DIFF
--- a/dandischema/datacite/__init__.py
+++ b/dandischema/datacite/__init__.py
@@ -79,11 +79,6 @@ def to_datacite(
         attributes["event"] = "publish"
 
     attributes["alternateIdentifiers"] = [
-        # TODO: the first element is ignored, not sure how to fix it...
-        {
-            "alternateIdentifier": f"https://doi.org/{meta.doi}",
-            "alternateIdentifierType": "DOI",
-        },
         {
             "alternateIdentifier": f"https://identifiers.org/{meta.id}",
             "alternateIdentifierType": "URL",

--- a/dandischema/datacite/__init__.py
+++ b/dandischema/datacite/__init__.py
@@ -172,7 +172,7 @@ def to_datacite(
                 contr_dict["affiliation"] = []
             if getattr(contr_el, "identifier"):
                 orcid_dict = {
-                    "nameIdentifier": contr_el.identifier,
+                    "nameIdentifier": f"https://orcid.org/{contr_el.identifier}",
                     "nameIdentifierScheme": "ORCID",
                     "schemeUri": "https://orcid.org/",
                 }

--- a/dandischema/datacite/__init__.py
+++ b/dandischema/datacite/__init__.py
@@ -255,7 +255,7 @@ def to_datacite(
 
 
 @lru_cache()
-def _get_datacite_schema(version_id: str = "datacite-4.3-17-gaa5db56") -> Any:
+def _get_datacite_schema(version_id: str = "inveniosoftware-4.5-81-g160250d") -> Any:
     """Load datacite schema based on the version id provided."""
     schema_folder = Path(__file__).parent / "schema"
     return json.loads((schema_folder / f"{version_id}.json").read_text())

--- a/dandischema/datacite/__init__.py
+++ b/dandischema/datacite/__init__.py
@@ -101,7 +101,13 @@ def to_datacite(
     attributes["descriptions"] = [
         {"description": meta.description, "descriptionType": "Abstract"}
     ]
-    attributes["publisher"] = "DANDI Archive"
+    attributes["publisher"] = {
+        "name": "DANDI Archive",
+        "schemeUri": "https://scicrunch.org/resolver/",
+        "publisherIdentifier": "https://scicrunch.org/resolver/RRID:SCR_017571",
+        "publisherIdentifierScheme": "RRID",
+        "lang": "en",
+    }
     attributes["publicationYear"] = str(meta.datePublished.year)
     # not sure about it dandi-api had "resourceTypeGeneral": "NWB"
     attributes["types"] = {
@@ -113,7 +119,7 @@ def to_datacite(
     # assuming that all licenses are from SPDX?
     attributes["rightsList"] = [
         {
-            "schemeURI": "https://spdx.org/licenses/",
+            "schemeUri": "https://spdx.org/licenses/",
             "rightsIdentifierScheme": "SPDX",
             "rightsIdentifier": el.name,
         }
@@ -150,7 +156,7 @@ def to_datacite(
         contr_dict: Dict[str, Any] = {
             "name": contr_el.name,
             "contributorName": contr_el.name,
-            "schemeURI": "orcid.org",
+            "schemeUri": "orcid.org",
         }
         if isinstance(contr_el, Person):
             contr_dict["nameType"] = "Personal"

--- a/dandischema/datacite/__init__.py
+++ b/dandischema/datacite/__init__.py
@@ -78,16 +78,19 @@ def to_datacite(
     if publish:
         attributes["event"] = "publish"
 
-    attributes["identifiers"] = [
+    attributes["alternateIdentifiers"] = [
         # TODO: the first element is ignored, not sure how to fix it...
-        {"identifier": f"https://doi.org/{meta.doi}", "identifierType": "DOI"},
         {
-            "identifier": f"https://identifiers.org/{meta.id}",
-            "identifierType": "URL",
+            "alternateIdentifier": f"https://doi.org/{meta.doi}",
+            "alternateIdentifierType": "DOI",
         },
         {
-            "identifier": str(meta.url),
-            "identifierType": "URL",
+            "alternateIdentifier": f"https://identifiers.org/{meta.id}",
+            "alternateIdentifierType": "URL",
+        },
+        {
+            "alternateIdentifier": str(meta.url),
+            "alternateIdentifierType": "URL",
         },
     ]
 

--- a/dandischema/datacite/tests/test_datacite.py
+++ b/dandischema/datacite/tests/test_datacite.py
@@ -452,13 +452,6 @@ def test_datacite_publish(metadata_basic: Dict[str, Any]) -> None:
                 "doi": f"10.80507/dandi.{dandi_id_noprefix}/{version}",
                 "alternateIdentifiers": [
                     {
-                        "alternateIdentifier": (
-                            f"https://doi.org/10.80507"
-                            f"/dandi.{dandi_id_noprefix}/{version}"
-                        ),
-                        "alternateIdentifierType": "DOI",
-                    },
-                    {
                         "alternateIdentifier": f"https://identifiers.org/{dandi_id}/{version}",
                         "alternateIdentifierType": "URL",
                     },

--- a/dandischema/datacite/tests/test_datacite.py
+++ b/dandischema/datacite/tests/test_datacite.py
@@ -150,7 +150,16 @@ def test_datacite(dandi_id: str, schema: Any) -> None:
                     1,
                     {"description": "testing", "descriptionType": "Abstract"},
                 ),
-                "publisher": (None, "DANDI Archive"),
+                "publisher": (
+                    None,
+                    {
+                        "name": "DANDI Archive",
+                        "publisherIdentifier": "https://scicrunch.org/resolver/RRID:SCR_017571",
+                        "publisherIdentifierScheme": "RRID",
+                        "schemeUri": "https://scicrunch.org/resolver/",
+                        "lang": "en",
+                    },
+                ),
                 "rightsList": (
                     1,
                     {"rightsIdentifierScheme": "SPDX", "rightsIdentifier": "CC_BY_40"},
@@ -423,7 +432,7 @@ def test_datacite_publish(metadata_basic: Dict[str, Any]) -> None:
                         "givenName": "A_first",
                         "name": "A_last, A_first",
                         "nameType": "Personal",
-                        "schemeURI": "orcid.org",
+                        "schemeUri": "orcid.org",
                     }
                 ],
                 "creators": [
@@ -434,7 +443,7 @@ def test_datacite_publish(metadata_basic: Dict[str, Any]) -> None:
                         "givenName": "A_first",
                         "name": "A_last, A_first",
                         "nameType": "Personal",
-                        "schemeURI": "orcid.org",
+                        "schemeUri": "orcid.org",
                     }
                 ],
                 "descriptions": [
@@ -462,12 +471,18 @@ def test_datacite_publish(metadata_basic: Dict[str, Any]) -> None:
                     },
                 ],
                 "publicationYear": "1970",
-                "publisher": "DANDI Archive",
+                "publisher": {
+                    "name": "DANDI Archive",
+                    "publisherIdentifier": "https://scicrunch.org/resolver/RRID:SCR_017571",
+                    "publisherIdentifierScheme": "RRID",
+                    "schemeUri": "https://scicrunch.org/resolver/",
+                    "lang": "en",
+                },
                 "rightsList": [
                     {
                         "rightsIdentifier": "CC_BY_40",
                         "rightsIdentifierScheme": "SPDX",
-                        "schemeURI": "https://spdx.org/licenses/",
+                        "schemeUri": "https://spdx.org/licenses/",
                     }
                 ],
                 "schemaVersion": "http://datacite.org/schema/kernel-4",

--- a/dandischema/datacite/tests/test_datacite.py
+++ b/dandischema/datacite/tests/test_datacite.py
@@ -311,7 +311,7 @@ def test_datacite(dandi_id: str, schema: Any) -> None:
                         "name": "A_last, A_first",
                         "nameIdentifiers": [
                             {
-                                "nameIdentifier": "0000-0001-0000-0000",
+                                "nameIdentifier": "https://orcid.org/0000-0001-0000-0000",
                                 "nameIdentifierScheme": "ORCID",
                                 "schemeUri": "https://orcid.org/",
                             }
@@ -325,7 +325,7 @@ def test_datacite(dandi_id: str, schema: Any) -> None:
                         "contributorType": "Other",
                         "nameIdentifiers": [
                             {
-                                "nameIdentifier": "0000-0001-0000-0000",
+                                "nameIdentifier": "https://orcid.org/0000-0001-0000-0000",
                                 "nameIdentifierScheme": "ORCID",
                                 "schemeUri": "https://orcid.org/",
                             }

--- a/dandischema/datacite/tests/test_datacite.py
+++ b/dandischema/datacite/tests/test_datacite.py
@@ -441,24 +441,24 @@ def test_datacite_publish(metadata_basic: Dict[str, Any]) -> None:
                     {"description": "testing", "descriptionType": "Abstract"}
                 ],
                 "doi": f"10.80507/dandi.{dandi_id_noprefix}/{version}",
-                "identifiers": [
+                "alternateIdentifiers": [
                     {
-                        "identifier": (
+                        "alternateIdentifier": (
                             f"https://doi.org/10.80507"
                             f"/dandi.{dandi_id_noprefix}/{version}"
                         ),
-                        "identifierType": "DOI",
+                        "alternateIdentifierType": "DOI",
                     },
                     {
-                        "identifier": f"https://identifiers.org/{dandi_id}/{version}",
-                        "identifierType": "URL",
+                        "alternateIdentifier": f"https://identifiers.org/{dandi_id}/{version}",
+                        "alternateIdentifierType": "URL",
                     },
                     {
-                        "identifier": (
+                        "alternateIdentifier": (
                             f"https://dandiarchive.org/dandiset"
                             f"/{dandi_id_noprefix}/{version}"
                         ),
-                        "identifierType": "URL",
+                        "alternateIdentifierType": "URL",
                     },
                 ],
                 "publicationYear": "1970",


### PR DESCRIPTION
Some extra info on "dichotomy" of datacite json serializations could be found in
- https://github.com/dandi/dandi-schema/issues/259

and there in.  Part of this effort is RFing use of "identifiers" (removed in 4.5 serialization)

Might want to wait for addressing need to include schemas as stated in https://github.com/dandi/dandi-schema/pull/260#issuecomment-2454982938 

@djarecka  you were looking into upgrades also on Friday -- what other items were due?