### PR TITLE
Improve (better arguments validation, avoiding repeated creation of validator objects, etc) `_validate_obj_json()` in `metadata.py` and supporting funcs

### DIFF
--- a/dandischema/tests/test_metadata.py
+++ b/dandischema/tests/test_metadata.py
@@ -3,14 +3,21 @@ from hashlib import md5, sha256
 import json
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, Set
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from jsonschema.protocols import Validator as JsonschemaValidator
+from pydantic import BaseModel
 import pytest
+
+from dandischema.models import Asset, Dandiset, PublishedAsset, PublishedDandiset
+from dandischema.utils import TransitionalGenerateJsonSchema, jsonschema_validator
 
 from .utils import skipif_no_network
 from ..consts import DANDI_SCHEMA_VERSION
 from ..exceptions import JsonschemaValidationError, PydanticValidationError
 from ..metadata import (
+    _get_jsonschema_validator,
+    _get_jsonschema_validator_local,
     _validate_asset_json,
     _validate_dandiset_json,
     _validate_obj_json,
@@ -677,13 +684,16 @@ class TestValidateObjJson:
     """
 
     @pytest.fixture
-    def dummy_schema(self) -> dict:
-        """Returns a dummy JSON schema."""
-        return {
-            "type": "object",
-            "properties": {"name": {"type": "string"}},
-            "required": ["name"],
-        }
+    def dummy_jvalidator(self) -> JsonschemaValidator:
+        """Returns a dummy jsonschema validator initialized with a dummy schema."""
+        return jsonschema_validator(
+            {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+            check_format=True,
+        )
 
     @pytest.fixture
     def dummy_instance(self) -> dict:
@@ -691,7 +701,10 @@ class TestValidateObjJson:
         return {"name": "Example"}
 
     def test_valid_obj_no_errors(
-        self, monkeypatch: pytest.MonkeyPatch, dummy_schema: dict, dummy_instance: dict
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        dummy_jvalidator: JsonschemaValidator,
+        dummy_instance: dict,
     ) -> None:
         """
         Test that `_validate_obj_json` does not raise when `validate_json` has no errors
@@ -707,10 +720,13 @@ class TestValidateObjJson:
         monkeypatch.setattr(metadata, "validate_json", mock_validate_json)
 
         # `_validate_obj_json` should succeed without raising an exception
-        _validate_obj_json(dummy_instance, dummy_schema)
+        _validate_obj_json(dummy_instance, dummy_jvalidator)
 
     def test_raises_error_without_missing_ok(
-        self, monkeypatch: pytest.MonkeyPatch, dummy_schema: dict, dummy_instance: dict
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        dummy_jvalidator: JsonschemaValidator,
+        dummy_instance: dict,
     ) -> None:
         """
         Test that `_validate_obj_json` forwards JsonschemaValidationError
@@ -730,7 +746,7 @@ class TestValidateObjJson:
 
         # Since `missing_ok=False`, any error should be re-raised.
         with pytest.raises(JsonschemaValidationError) as excinfo:
-            _validate_obj_json(dummy_instance, dummy_schema, missing_ok=False)
+            _validate_obj_json(dummy_instance, dummy_jvalidator, missing_ok=False)
         assert "`name` is a required property" == excinfo.value.errors[0].message
 
     @pytest.mark.parametrize(
@@ -759,7 +775,7 @@ class TestValidateObjJson:
     def test_raises_only_nonmissing_errors_with_missing_ok(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        dummy_schema: dict,
+        dummy_jvalidator: JsonschemaValidator,
         dummy_instance: dict,
         validation_errs: list[MagicMock],
         expect_raises: bool,
@@ -789,7 +805,7 @@ class TestValidateObjJson:
         )
 
         with ctx as excinfo:
-            _validate_obj_json(dummy_instance, dummy_schema, missing_ok=True)
+            _validate_obj_json(dummy_instance, dummy_jvalidator, missing_ok=True)
 
         if excinfo is not None:
             filtered_errors = excinfo.value.errors
@@ -797,3 +813,146 @@ class TestValidateObjJson:
             # We expect the "required property" error to be filtered out,
             # so we should only see the "Some other validation error".
             assert len(filtered_errors) == expected_remaining_errs_count
+
+
+class TestGetJsonschemaValidator:
+    @pytest.mark.parametrize(
+        "schema_version, schema_key, expected_error_msg",
+        [
+            pytest.param(
+                "0.5.8",
+                "Dandiset",
+                "DANDI schema version 0.5.8 is not allowed",
+                id="invalid-schema-version",
+            ),
+            pytest.param(
+                "0.6.0",
+                "Nonexistent",
+                "Schema key must be one of",
+                id="invalid-schema-key",
+            ),
+        ],
+    )
+    def test_invalid_parameters(
+        self, schema_version: str, schema_key: str, expected_error_msg: str
+    ) -> None:
+        """
+        Test that providing an invalid schema version or key raises ValueError.
+        """
+        # Clear the cache to avoid interference from previous calls
+        _get_jsonschema_validator.cache_clear()
+        with pytest.raises(ValueError, match=expected_error_msg):
+            _get_jsonschema_validator(schema_version, schema_key)
+
+    def test_valid_schema(self) -> None:
+        """
+        Test the valid case:
+          - requests.get() is patched directly using patch("requests.get")
+          - The returned JSON is a valid dict
+          - The resulting validator is produced via dandi_jsonschema_validator
+        """
+        valid_version = "0.6.0"
+        valid_key = "Dandiset"
+        expected_url = (
+            f"https://raw.githubusercontent.com/dandi/schema/master/releases/"
+            f"{valid_version}/dandiset.json"
+        )
+        dummy_validator = MagicMock(spec=JsonschemaValidator)
+        valid_schema = {"type": "object"}
+
+        with patch("requests.get") as mock_get, patch(
+            "dandischema.metadata.dandi_jsonschema_validator",
+            return_value=dummy_validator,
+        ) as mock_validator:
+            mock_response = MagicMock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = valid_schema
+            mock_get.return_value = mock_response
+
+            # Clear the cache to avoid interference from previous calls
+            _get_jsonschema_validator.cache_clear()
+            result = _get_jsonschema_validator(valid_version, valid_key)
+
+            mock_get.assert_called_once_with(expected_url)
+            mock_response.raise_for_status.assert_called_once()
+            mock_response.json.assert_called_once()
+            mock_validator.assert_called_once_with(valid_schema)
+            assert result is dummy_validator
+
+    def test_invalid_json_schema_raises_runtime_error(self) -> None:
+        """
+        Test that if the fetched schema is not a valid JSON object,
+        then _get_jsonschema_validator() raises a RuntimeError.
+        """
+        valid_version = "0.6.0"
+        valid_key = "Dandiset"
+        expected_url = (
+            f"https://raw.githubusercontent.com/dandi/schema/master/releases/"
+            f"{valid_version}/dandiset.json"
+        )
+        # Return a list (instead of a dict) to trigger a ValidationError in json_object_adapter
+        invalid_schema = {4: 2}
+
+        with patch("requests.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.raise_for_status.return_value = None
+            mock_response.json.return_value = invalid_schema
+            mock_get.return_value = mock_response
+
+            # Clear the cache to avoid interference from previous calls
+            _get_jsonschema_validator.cache_clear()
+            with pytest.raises(RuntimeError, match="not a valid JSON object"):
+                _get_jsonschema_validator(valid_version, valid_key)
+
+            mock_get.assert_called_once_with(expected_url)
+            mock_response.raise_for_status.assert_called_once()
+            mock_response.json.assert_called_once()
+
+
+class TestGetJsonschemaValidatorLocal:
+    @pytest.mark.parametrize(
+        ("schema_key", "pydantic_model"),
+        [
+            pytest.param("Dandiset", Dandiset, id="valid-Dandiset"),
+            pytest.param(
+                "PublishedDandiset", PublishedDandiset, id="valid-PublishedDandiset"
+            ),
+            pytest.param("Asset", Asset, id="valid-Asset"),
+            pytest.param("PublishedAsset", PublishedAsset, id="valid-PublishedAsset"),
+        ],
+    )
+    def test_valid_schema_keys(
+        self, schema_key: str, pydantic_model: type[BaseModel]
+    ) -> None:
+        # Get the expected schema from the corresponding model.
+        expected_schema = pydantic_model.model_json_schema(
+            schema_generator=TransitionalGenerateJsonSchema
+        )
+
+        # Clear the cache to avoid interference from previous calls
+        _get_jsonschema_validator_local.cache_clear()
+
+        # Call the function under test.
+        validator = _get_jsonschema_validator_local(schema_key)
+
+        # Assert that the returned validator has a 'schema' attribute
+        # equal to the expected schema.
+        assert validator.schema == expected_schema, (
+            f"For schema key {schema_key!r}, expected schema:\n{expected_schema}\n"
+            f"but got:\n{validator.schema}"
+        )
+
+    @pytest.mark.parametrize(
+        "invalid_schema_key",
+        [
+            pytest.param("Nonexistent", id="invalid-Nonexistent"),
+            pytest.param("", id="invalid-empty-string"),
+            pytest.param("InvalidKey", id="invalid-Key"),
+        ],
+    )
+    def test_invalid_schema_keys(self, invalid_schema_key: str) -> None:
+        # Clear the cache to avoid interference from previous calls
+        _get_jsonschema_validator_local.cache_clear()
+
+        with pytest.raises(ValueError, match="Schema key must be one of"):
+            _get_jsonschema_validator_local(invalid_schema_key)

--- a/dandischema/tests/test_utils.py
+++ b/dandischema/tests/test_utils.py
@@ -1,6 +1,12 @@
-from typing import Dict, List, Optional, Union
+from contextlib import nullcontext
+from typing import Dict, List, Optional, Union, cast
 
+from jsonschema.exceptions import SchemaError, ValidationError
+from jsonschema.protocols import Validator as JsonschemaValidator
+from jsonschema.validators import Draft7Validator, Draft202012Validator
 import pytest
+
+from dandischema.utils import jsonschema_validator
 
 from ..utils import (
     _ensure_newline,
@@ -88,3 +94,164 @@ def test_sanitize_value() -> None:
     assert sanitize_value("A;B") == "A-B"
     assert sanitize_value("A\\/B") == "A--B"
     assert sanitize_value("A\"'B") == "A--B"
+
+
+@pytest.fixture
+def draft7_schema() -> dict:
+    """
+    A minimal valid Draft 7 schema requiring a 'name' property of type 'string'.
+    """
+    return {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+    }
+
+
+@pytest.fixture
+def draft202012_schema() -> dict:
+    """
+    A minimal valid Draft 2020-12 schema requiring a 'title' property of type 'string'.
+    """
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {"title": {"type": "string"}},
+        "required": ["title"],
+    }
+
+
+@pytest.fixture
+def draft202012_format_schema() -> dict:
+    """
+    Draft 2020-12 schema that includes a 'format' requirement (e.g., 'email').
+    Used to test the 'check_format' parameter.
+    """
+    return {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": {"email": {"type": "string", "format": "email"}},
+        "required": ["email"],
+    }
+
+
+@pytest.fixture
+def schema_no_dollar_schema() -> dict:
+    """
+    Schema that lacks the '$schema' property altogether.
+    Used to test that 'default_cls' is applied.
+    """
+    return {
+        "type": "object",
+        "properties": {"foo": {"type": "string"}},
+        "required": ["foo"],
+    }
+
+
+class TestJsonschemaValidator:
+    @pytest.mark.parametrize(
+        ("fixture_name", "expected_validator_cls"),
+        [
+            pytest.param(
+                "draft202012_format_schema", Draft202012Validator, id="Draft202012"
+            ),
+            pytest.param("draft7_schema", Draft7Validator, id="Draft7"),
+        ],
+    )
+    @pytest.mark.parametrize("check_format", [True, False])
+    def test_set_by_dollar_schema(
+        self,
+        request: pytest.FixtureRequest,
+        fixture_name: str,
+        expected_validator_cls: type,
+        check_format: bool,
+    ) -> None:
+        """
+        Test that the correct validator class is returned for different '$schema' values
+        """
+        # Dynamically retrieve the appropriate fixture schema based on fixture_name
+        schema = request.getfixturevalue(fixture_name)
+
+        validator = jsonschema_validator(schema, check_format=check_format)
+
+        assert isinstance(validator, expected_validator_cls)
+
+    @pytest.mark.parametrize(
+        ("check_format", "instance", "expect_raises"),
+        [
+            (True, {"email": "test@example.com"}, False),
+            (True, {"email": "not-an-email"}, True),
+            (False, {"email": "not-an-email"}, False),
+        ],
+        ids=[
+            "check_format=True, valid email",
+            "check_format=True, invalid email",
+            "check_format=False, invalid email",
+        ],
+    )
+    def test_check_format_email_scenarios(
+        self,
+        draft202012_format_schema: dict,
+        check_format: bool,
+        instance: dict,
+        expect_raises: bool,
+    ) -> None:
+        """
+        Parametrized test for check_format usage on valid/invalid email addresses under
+        Draft202012Validator.
+        """
+        validator = jsonschema_validator(
+            draft202012_format_schema, check_format=check_format
+        )
+
+        # If expect_raises is True, we use pytest.raises(ValidationError)
+        # Otherwise, we enter a no-op context
+        ctx = pytest.raises(ValidationError) if expect_raises else nullcontext()
+
+        with ctx:
+            validator.validate(instance)  # Should raise or not raise as parametrized
+
+    @pytest.mark.parametrize(
+        ("schema_fixture", "expected_validator_cls"),
+        [
+            # Scenario 1: no $schema => we expect the default_cls=Draft7Validator is used
+            pytest.param("schema_no_dollar_schema", Draft7Validator, id="no-$schema"),
+            # Scenario 2: has $schema => draft 2020-12 overrides the default_cls
+            pytest.param("draft202012_schema", Draft202012Validator, id="with-$schema"),
+        ],
+    )
+    def test_default_cls(
+        self,
+        request: pytest.FixtureRequest,
+        schema_fixture: str,
+        expected_validator_cls: type,
+    ) -> None:
+        """
+        If the schema has no '$schema' property, and we provide a 'default_cls',
+        the returned validator should be an instance of that class.
+
+        If the schema *does* have '$schema', then the default_cls is ignored, and
+        the validator class is inferred from the schema's '$schema' field.
+        """
+        # Dynamically grab whichever fixture is specified by schema_fixture:
+        schema = request.getfixturevalue(schema_fixture)
+
+        # Provide default_cls=Draft7Validator
+        validator = jsonschema_validator(
+            schema,
+            check_format=False,
+            default_cls=cast(type[JsonschemaValidator], Draft7Validator),
+        )
+        assert isinstance(validator, expected_validator_cls)
+
+    def test_invalid_schema_raises_schema_error(self) -> None:
+        """
+        Provide an invalid schema, ensuring that 'SchemaError' is raised.
+        """
+        invalid_schema = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": 123,  # 'type' must be string/array, so this is invalid
+        }
+        with pytest.raises(SchemaError):
+            jsonschema_validator(invalid_schema, check_format=False)


### PR DESCRIPTION
This PR make the following improvement relating to validating metadata instances against a DANDI model's JSON schema.

1. Redefine the interface of `_validate_obj_json()` so that it take a jsonschema validator instead of a JSON schema as argument to avoid recreation of validators for the same schema.
2. Define a utility function, `jsonschema_validator(), for creating an appropriate JSON schema validator given a schema.
    1. Ensure validity of the schema is [checked](https://python-jsonschema.readthedocs.io/en/stable/validate/#the-validator-protocol) to prevent undefined behavior. (A bug fix)
    2. Utilized the `"$schema"` property in a provide schema to determine the appropriate validator class
2. Define a utility function, `validate_json()`, to validate a data instance in general, without the `missing_ok` parameter.
3. Define a utility function, `dandi_jsonschema_validator`, that decides the default/fallback validator class to used based on the `"schemaVersion"` property of the given schema instead of the `"schemaVersion"` field of a given instance.  (A bug fix)
4. Define utility functions, `_get_jsonschema_validator()`and `_get_jsonschema_validator_local()`, with cache to avoid repeated creation of jsonschema validators for the same schemas. **Note**: `functools.cache()` instead of `functools.lru_cache()` is used, for improved performance, in these functions because valid inputs to these functions have been limited by validation, so there is no worry about the cache growing without bound.
5. Reimplement `_validate_obj_json()` using the aforementioned utility functions
6. Rename `schema_map` in `metadata.py` to `SCHEMA_MAP` for the reference dictionary is a constant.
7. Add extensive tests to functions covered in this PR.
