### PR TITLE
Avoid multiple assignments of constant `ALLOWED_INPUT_SCHEMAS`

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -12,15 +12,16 @@ ALLOWED_INPUT_SCHEMAS = [
     "0.6.6",
     "0.6.7",
     "0.6.8",
+    DANDI_SCHEMA_VERSION,
 ]
 
 # ATM we allow only for a single target version which is current
 # migrate has a guard now for this since it cannot migrate to anything but current
 # version
 ALLOWED_TARGET_SCHEMAS = [DANDI_SCHEMA_VERSION]
+
 # This allows multiple schemas for validation, whereas target schemas focus on
 # migration.
-ALLOWED_VALIDATION_SCHEMAS = ALLOWED_TARGET_SCHEMAS + ALLOWED_INPUT_SCHEMAS
-
-if DANDI_SCHEMA_VERSION not in ALLOWED_INPUT_SCHEMAS:
-    ALLOWED_INPUT_SCHEMAS.append(DANDI_SCHEMA_VERSION)
+ALLOWED_VALIDATION_SCHEMAS = sorted(
+    set(ALLOWED_INPUT_SCHEMAS).union(ALLOWED_TARGET_SCHEMAS)
+)


### PR DESCRIPTION
This PR avoids multiple assignment of the constant `ALLOWED_INPUT_SCHEMAS`. Incidentally, it improves readability, and ensures `ALLOWED_VALIDATION_SCHEMAS` is always sorted.

Please, also checkout an [alternative](https://github.com/dandi/dandi-schema/pull/280/files/c44d1f3accd3c91041d39b1921a7f988d664deb4#r1938754892) to this PR posted below.