### PR TITLE
Use `[]` as default affiliation value

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -1,4 +1,4 @@
-DANDI_SCHEMA_VERSION = "0.6.9"
+DANDI_SCHEMA_VERSION = "0.6.10"
 ALLOWED_INPUT_SCHEMAS = [
     "0.4.4",
     "0.5.1",
@@ -12,6 +12,7 @@ ALLOWED_INPUT_SCHEMAS = [
     "0.6.6",
     "0.6.7",
     "0.6.8",
+    "0.6.9",
     DANDI_SCHEMA_VERSION,
 ]
 

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -952,7 +952,7 @@ class Person(Contributor):
         json_schema_extra={"nskey": "schema"},
     )
     affiliation: Optional[List[Affiliation]] = Field(
-        None,
+        default=[],
         description="An organization that this person is affiliated with.",
         json_schema_extra={"nskey": "schema"},
     )


### PR DESCRIPTION
This provides `[]` as a default value for `Person.affiliation`, which is typed as a list of `Affiliation`. The current default value of `null` causes problems when trying to process an empty affiliation value in the DANDI Archive meditor (see https://github.com/dandi/dandi-archive/issues/2150).