### PR TITLE
Duplicate Publishable attributes in CommonModel + DOI in Dandiset as Optional

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -1,4 +1,4 @@
-DANDI_SCHEMA_VERSION = "0.6.9"
+DANDI_SCHEMA_VERSION = "0.6.10"
 ALLOWED_INPUT_SCHEMAS = [
     "0.4.4",
     "0.5.1",
@@ -12,6 +12,7 @@ ALLOWED_INPUT_SCHEMAS = [
     "0.6.6",
     "0.6.7",
     "0.6.8",
+    "0.6.9",
     DANDI_SCHEMA_VERSION,
 ]
 

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -1580,6 +1580,20 @@ class CommonModel(DandiBaseModel):
     wasGeneratedBy: Optional[Sequence[Activity]] = Field(
         None, json_schema_extra={"nskey": "prov"}
     )
+
+    # Our current draft dandisets could be coming from Published ones,
+    # and thus carry their attributes. So we would need to define them here as well
+    # but make them optional, and `Publishable` would overload to make
+    # them mandatory.
+    publishedBy: Optional[Union[AnyHttpUrl, PublishActivity]] = Field(
+        default=None,
+        description="The URL should contain the provenance of the publishing process.",
+        json_schema_extra={"readOnly": True, "nskey": "dandi"},
+    )
+    datePublished: Optional[datetime] = Field(
+        default=None, json_schema_extra={"readOnly": True, "nskey": "schema"}
+    )
+
     schemaKey: str = Field(
         "CommonModel", validate_default=True, json_schema_extra={"readOnly": True}
     )
@@ -1667,6 +1681,12 @@ class Dandiset(CommonModel):
 
     version: str = Field(json_schema_extra={"nskey": "schema", "readOnly": True})
 
+    doi: Optional[str] = Field(
+        None,
+        title="DOI",
+        pattern=DANDI_DOI_PATTERN,
+        json_schema_extra={"readOnly": True, "nskey": "dandi"},
+    )
     wasGeneratedBy: Optional[Sequence[Project]] = Field(
         None,
         title="Associated projects",


### PR DESCRIPTION
That is necessary to later be able to make our model more restrictive and disallow addition of arbitrary attributes as it does now.

ATM any Draft version of a dandiset which was already published at least once, would have those attributes although base Dandiset (similar in Asset model; @candleindark would check) does not have them defined. This is what this PR fixes.

More details on how those were found and in which dandisets could be obtained from https://github.com/dandi/dandi-schema-status/blob/main/reports/diff_reports/dandiset/jsonschema_errs_summary.md#errs-diff-detailed-tables

This should be "backward compatible" change at the level of the schema, as any prior valid record would remain valid. Hence just boosting the "patch" portion of the version