### PR TITLE
Increase `Description` field max character length

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -1,4 +1,4 @@
-DANDI_SCHEMA_VERSION = "0.6.10"
+DANDI_SCHEMA_VERSION = "0.6.11"
 ALLOWED_INPUT_SCHEMAS = [
     "0.4.4",
     "0.5.1",
@@ -13,6 +13,7 @@ ALLOWED_INPUT_SCHEMAS = [
     "0.6.7",
     "0.6.8",
     "0.6.9",
+    "0.6.10",
     DANDI_SCHEMA_VERSION,
 ]
 

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -1623,7 +1623,7 @@ class Dandiset(CommonModel):
     )
     description: str = Field(
         description="A description of the Dandiset",
-        max_length=3000,
+        max_length=10000,
         json_schema_extra={"nskey": "schema"},
     )
     contributor: List[


### PR DESCRIPTION
Fix #295 

10,000 characters is about 2-3 single-spaced pages.  Based on the OpenScope use case, the dataset descriptions (https://openscopedatafront.web.app/datasets) will fit within 10,000 characters.  See here for the context: https://github.com/dandi/dandi-archive/issues/2297.