### PR TITLE
Revert version of schema to 0.6.10 since we have not yet released it

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -1,4 +1,4 @@
-DANDI_SCHEMA_VERSION = "0.6.11"
+DANDI_SCHEMA_VERSION = "0.6.10"
 ALLOWED_INPUT_SCHEMAS = [
     "0.4.4",
     "0.5.1",
@@ -13,7 +13,6 @@ ALLOWED_INPUT_SCHEMAS = [
     "0.6.7",
     "0.6.8",
     "0.6.9",
-    "0.6.10",
     DANDI_SCHEMA_VERSION,
 ]
 


### PR DESCRIPTION
Currently we have

    ❯ git describe schema-0.6.9
    schema-0.6.9
    ❯ git describe --match 0.* schema-0.6.9
    0.11.0
    ❯ git describe
    schema-0.6.9-22-g84bef7e
    ❯ git describe --match 0.*
    0.11.0-22-g84bef7e

so we have 0.6.9 schema released in prior (current) 0.11.0 release of this package. So the next release needs to just boost schema version once.

We will also take this PR as an opportunity to release (attn @kabilar , you wanted that didn't you?)