### PR TITLE
Add version sorting helper using packaging.version

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -23,6 +23,8 @@ ALLOWED_TARGET_SCHEMAS = [DANDI_SCHEMA_VERSION]
 
 # This allows multiple schemas for validation, whereas target schemas focus on
 # migration.
+# We use simple sorted() here to avoid circular imports, but use
+# utils.sort_versions() if to output to the user
 ALLOWED_VALIDATION_SCHEMAS = sorted(
     set(ALLOWED_INPUT_SCHEMAS).union(ALLOWED_TARGET_SCHEMAS)
 )

--- a/dandischema/metadata.py
+++ b/dandischema/metadata.py
@@ -24,6 +24,7 @@ from .utils import (
     dandi_jsonschema_validator,
     json_object_adapter,
     sanitize_value,
+    sort_versions,
     strip_top_level_optional,
     validate_json,
     version2tuple,
@@ -215,7 +216,7 @@ def _get_jsonschema_validator(
     if schema_version not in ALLOWED_VALIDATION_SCHEMAS:
         raise ValueError(
             f"DANDI schema version {schema_version} is not allowed. "
-            f"Allowed are: {', '.join(ALLOWED_VALIDATION_SCHEMAS)}."
+            f"Allowed are: {', '.join(sort_versions(ALLOWED_VALIDATION_SCHEMAS))}."
         )
     if schema_key not in SCHEMA_MAP:
         raise ValueError(
@@ -312,7 +313,7 @@ def validate(
     if schema_version not in ALLOWED_VALIDATION_SCHEMAS and schema_key in SCHEMA_MAP:
         raise ValueError(
             f"Metadata version {schema_version} is not allowed. "
-            f"Allowed are: {', '.join(ALLOWED_VALIDATION_SCHEMAS)}."
+            f"Allowed are: {', '.join(sort_versions(ALLOWED_VALIDATION_SCHEMAS))}."
         )
     if json_validation:
         if schema_version == DANDI_SCHEMA_VERSION:
@@ -488,7 +489,7 @@ def _add_asset_to_stats(assetmeta: Dict[str, Any], stats: _stats_type) -> None:
     if schema_version not in ALLOWED_INPUT_SCHEMAS:
         raise ValueError(
             f"Metadata version {schema_version} is not allowed. "
-            f"Allowed are: {', '.join(ALLOWED_INPUT_SCHEMAS)}."
+            f"Allowed are: {', '.join(sort_versions(ALLOWED_INPUT_SCHEMAS))}."
         )
 
     stats["numberOfBytes"] = stats.get("numberOfBytes", 0)

--- a/dandischema/tests/test_utils.py
+++ b/dandischema/tests/test_utils.py
@@ -14,6 +14,7 @@ from dandischema.utils import (
     jsonschema_validator,
     name2title,
     sanitize_value,
+    sort_versions,
     strip_top_level_optional,
     validate_json,
     version2tuple,
@@ -97,6 +98,21 @@ def test_sanitize_value() -> None:
     assert sanitize_value("A;B") == "A-B"
     assert sanitize_value("A\\/B") == "A--B"
     assert sanitize_value("A\"'B") == "A--B"
+
+
+def test_sort_versions() -> None:
+    """Test that sort_versions correctly sorts version strings semantically."""
+    # Test for correct semantic version sorting
+    unsorted_versions = ["0.6.2", "0.6.10", "0.6.1", "0.5.1", "0.6.0", "0.4.4"]
+    expected_sort = ["0.4.4", "0.5.1", "0.6.0", "0.6.1", "0.6.2", "0.6.10"]
+
+    assert sort_versions(unsorted_versions) == expected_sort
+
+    # Test with empty list
+    assert sort_versions([]) == []
+
+    # Test with single element
+    assert sort_versions(["0.6.0"]) == ["0.6.0"]
 
 
 @pytest.fixture

--- a/dandischema/utils.py
+++ b/dandischema/utils.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Iterator, List, Union, cast, get_args, get_origin
+from typing import Any, Iterator, List, Sequence, Union, cast, get_args, get_origin
 
 from jsonschema import Draft7Validator, Draft202012Validator
 from jsonschema.protocols import Validator as JsonschemaValidator
 from jsonschema.validators import validator_for
+from packaging.version import Version
 from pydantic import ConfigDict, TypeAdapter
 from pydantic.json_schema import GenerateJsonSchema, JsonSchemaMode, JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
@@ -241,3 +242,17 @@ def validate_json(instance: Any, validator: JsonschemaValidator) -> None:
 
 # Pydantic type adapter for a JSON object, which is of type `dict[str, Any]`
 json_object_adapter = TypeAdapter(dict[str, Any], config=ConfigDict(strict=True))
+
+
+def sort_versions(versions: Sequence[str]) -> list[str]:
+    """
+    Sort version strings in proper version order using packaging.version
+
+    This function sorts a list of version strings semantically rather
+    than lexicographically, ensuring correct ordering of versions
+    (e.g., "0.6.10" comes after "0.6.9", not before "0.6.2").
+
+    :param versions: A sequence of version strings to sort
+    :return: A list of version strings sorted in proper version order
+    """
+    return sorted(versions, key=Version)

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ project_urls =
 python_requires = >=3.9
 install_requires =
     jsonschema[format]
+    packaging
     pydantic[email] ~= 2.4
     requests
     zarr_checksum


### PR DESCRIPTION
- Add sort_versions utility function to properly sort version strings
- Update error messages to use this function for better readability
- Add packaging as a dependency
- Add tests for the new function

🤖 Generated with [Claude Code](https://claude.ai/code)

@yarikoptic observed in some CI run 

```
"message": "Metadata version 0.6.10 is not allowed. Allowed are: 0.6.9, 0.4.4, 0.5.1, 0.5.2, 0.6.0, 0.6.1, 0.6.2, 0.6.3, 0.6.4, 0.6.5, 0.6.6, 0.6.7, 0.6.8.",
```
and got confused since missed that 0.6.9 was listed at all ... 

With this change we should get more consistent reporting

the only possible gotcha I am afraid off, whenever we manage to sneak in non 'x.y.z' version, but that should not happen AFAIK.