### PR TITLE
Replace GH runner image `windows-2019` with `windows-latest`

### DIFF
--- a/.github/workflows/test-dandi-cli.yml
+++ b/.github/workflows/test-dandi-cli.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2019
+          - windows-latest
           - ubuntu-latest
           - macos-latest
         python:
@@ -45,7 +45,7 @@ jobs:
         exclude:
           # Temporarily disabled due to h5py/hdf5 dependency issue
           # See <https://github.com/dandi/dandi-cli/pull/315>
-          - os: windows-2019
+          - os: windows-latest
             python: 3.9
     steps:
       - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/test-nonetwork.yml
+++ b/.github/workflows/test-nonetwork.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2019
+          - windows-latest
           - ubuntu-latest
           - macos-latest
         python:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2019
+          - windows-latest
           - ubuntu-latest
           - macos-latest
         python:


### PR DESCRIPTION
The `windows-2019` image is deprecated. For more details, checkout https://github.com/actions/runner-images/issues/12045