### PR TITLE
Provide mechanism to reset instance configuration by function arguments, not env vars

### DIFF
--- a/dandischema/__init__.py
+++ b/dandischema/__init__.py
@@ -1,4 +1,3 @@
-__all__ = ["__version__", "migrate", "validate"]
+__all__ = ["__version__"]
 
 from ._version import __version__
-from .metadata import migrate, validate

--- a/dandischema/conf.py
+++ b/dandischema/conf.py
@@ -2,13 +2,19 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated, Any, Optional
 
 from pydantic import StringConstraints
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+_MODELS_MODULE_NAME = "dandischema.models"
+"""The full import name of the module containing the DANDI Pydantic models"""
+
 _UNVENDORED_ID_PATTERN = r"[A-Z][-A-Z]*"
 _UNVENDORED_DATACITE_DOI_ID_PATTERN = r"\d{4,}"
+
+logger = logging.getLogger(__name__)
 
 
 class Config(BaseSettings):
@@ -115,6 +121,14 @@ def reset_instance_config(**kwargs: Any) -> None:
         `dandischema.models`.
 
     """
-    # todo: give a warning if the `models.py` is already imported
+    import sys
+
+    if _MODELS_MODULE_NAME in sys.modules:
+        logger.warning(
+            f"{_MODELS_MODULE_NAME}` is already imported. Resetting the DANDI instance "
+            "configuration will not have any affect on the models defined in "
+            f"`{_MODELS_MODULE_NAME}`. "
+        )
+
     global _instance_config
     _instance_config = Config(**kwargs)

--- a/dandischema/conf.py
+++ b/dandischema/conf.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional
 
 from pydantic import StringConstraints
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -66,3 +66,55 @@ Configuration of the DANDI instance
 This configuration holds the information used to customize the DANDI schema to a
 specific vendor
 """
+
+
+_instance_config = Config()  # Initial value is set by env vars alone
+"""
+Configuration of the DANDI instance
+
+This configuration holds the information used to customize the DANDI schema to a
+specific vendor, but it should not be accessed directly. Use `get_instance_config()`
+to obtain its value and `reset_instance_config()` to reset its value.
+"""
+
+
+def get_instance_config() -> Config:
+    """
+    Get the configuration of the DANDI instance
+
+    This configuration holds the information used to customize the DANDI schema to a
+    specific vendor.
+
+    Returns
+    -------
+    Config
+        The configuration of the DANDI instance
+    """
+    return _instance_config.model_copy(deep=True)
+
+
+def reset_instance_config(**kwargs: Any) -> None:
+    """
+    Reset the configuration of the DANDI instance returned by `get_instance_config()`
+
+    The resetting is done by re-recreating a new instance of `Config` with the keyword
+    arguments passed to this function.
+
+    Parameters
+    ----------
+    **kwargs
+        Keyword arguments to pass to the `Config` constructor
+
+    Note
+    ----
+        Use this function to override the configuration set by the environment
+        variables.
+
+        This function should be called before importing `dandischema.models` or the
+        new configuration will not have any affect in the models defined in
+        `dandischema.models`.
+
+    """
+    # todo: give a warning if the `models.py` is already imported
+    global _instance_config
+    _instance_config = Config(**kwargs)

--- a/dandischema/conf.py
+++ b/dandischema/conf.py
@@ -65,15 +65,6 @@ class Config(BaseSettings):
         return self.datacite_doi_id
 
 
-INSTANCE_CONFIG = Config()
-"""
-Configuration of the DANDI instance
-
-This configuration holds the information used to customize the DANDI schema to a
-specific vendor
-"""
-
-
 _instance_config = Config()  # Initial value is set by env vars alone
 """
 Configuration of the DANDI instance

--- a/dandischema/datacite/tests/test_datacite.py
+++ b/dandischema/datacite/tests/test_datacite.py
@@ -31,6 +31,11 @@ from .. import _get_datacite_schema, to_datacite
 def datacite_post(datacite: dict, doi: str) -> None:
     """Post the datacite object and check the status of the request"""
 
+    print(f"posting datacite object with doi {doi}")
+    print(f"INSTANCE_NAME: {INSTANCE_NAME}")
+    print(f"DOI_PREFIX: {DOI_PREFIX}")
+    print(f"payload: \n{json.dumps(datacite, indent=2)}")
+
     # removing doi in case it exists
     _clean_doi(doi)
 

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -36,7 +36,7 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema
 from zarr_checksum.checksum import InvalidZarrChecksum, ZarrDirectoryDigest
 
-from dandischema.conf import INSTANCE_CONFIG
+from dandischema.conf import get_instance_config
 
 from .consts import DANDI_SCHEMA_VERSION
 from .digests.dandietag import DandiETag
@@ -44,8 +44,9 @@ from .types import ByteSizeJsonSchema
 from .utils import name2title
 
 # Load needed configurations into constants
-ID_PATTERN = INSTANCE_CONFIG.id_pattern
-DATACITE_DOI_ID_PATTERN = INSTANCE_CONFIG.datacite_doi_id_pattern
+_INSTANCE_CONFIG = get_instance_config()
+ID_PATTERN = _INSTANCE_CONFIG.id_pattern
+DATACITE_DOI_ID_PATTERN = _INSTANCE_CONFIG.datacite_doi_id_pattern
 
 # Use DJANGO_DANDI_WEB_APP_URL to point to a specific deployment.
 DANDI_INSTANCE_URL: Optional[str]

--- a/dandischema/tests/utils.py
+++ b/dandischema/tests/utils.py
@@ -5,10 +5,11 @@ from typing import Any, Dict
 
 import pytest
 
-from dandischema.conf import INSTANCE_CONFIG
+from dandischema.conf import get_instance_config
 
-INSTANCE_NAME = INSTANCE_CONFIG.instance_name
-DATACITE_DOI_ID = INSTANCE_CONFIG.datacite_doi_id
+_INSTANCE_CONFIG = get_instance_config()
+INSTANCE_NAME = _INSTANCE_CONFIG.instance_name
+DATACITE_DOI_ID = _INSTANCE_CONFIG.datacite_doi_id
 
 METADATA_DIR = Path(__file__).with_name("data") / "metadata"
 DANDISET_METADATA_DIR = METADATA_DIR / INSTANCE_NAME


### PR DESCRIPTION
This is a replacement of https://github.com/dandi/dandi-schema/pull/304, which has been marked as merged to the `devendorize` branch however changes in `devendorize` was later written.

This PR provide a mechanism to reset DANDI instance configuration by function arguments, not env vars. This future is a step in supporting `dandi-cli` to initialize DANDI schema models to a particular vendor in order to communicate with a DANDI service of a particular vendor.

**Breaking change**
1. `migrate()` and `validate()` are not available at `dandischema` level. To use them, one must do `from dandischema.metadata import migrate, validate` instead of `from dandischema import migrate, validate`.