### PR TITLE
Escape `<` and `>` properly in `description`

### DIFF
--- a/dandischema/consts.py
+++ b/dandischema/consts.py
@@ -1,6 +1,6 @@
 from packaging.version import Version as _Version
 
-DANDI_SCHEMA_VERSION = "0.6.10"
+DANDI_SCHEMA_VERSION = "0.6.11"
 ALLOWED_INPUT_SCHEMAS = [
     "0.4.4",
     "0.5.1",
@@ -15,6 +15,7 @@ ALLOWED_INPUT_SCHEMAS = [
     "0.6.7",
     "0.6.8",
     "0.6.9",
+    "0.6.10",
     DANDI_SCHEMA_VERSION,
 ]
 

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -1048,7 +1048,7 @@ class Resource(DandiBaseModel):
     relation: RelationType = Field(
         title="Resource relation",
         description="Indicates how the resource is related to the dataset. "
-        "This relation should satisfy: dandiset <relation> resource.",
+        r"This relation should satisfy: dandiset \<relation\> resource.",
         json_schema_extra={"nskey": "dandi"},
     )
     resourceType: Optional[ResourceType] = Field(
@@ -1332,7 +1332,7 @@ class RelatedParticipant(DandiBaseModel):
         title="Participant or subject relation",
         description="Indicates how the current participant or subject is related "
         "to the other participant or subject. This relation should "
-        "satisfy: Participant/Subject <relation> relatedParticipant/Subject.",
+        r"satisfy: Participant/Subject \<relation\> relatedParticipant/Subject.",
         json_schema_extra={"nskey": "dandi"},
     )
     schemaKey: Literal["RelatedParticipant"] = Field(


### PR DESCRIPTION
Fixes dandi/dandi-archive#2432 

Currently, the `<` and `>` characters in the description field of the help tooltip are not escaped, which can causes a rendering issue where every character in between the `<` and `>` is not rendered.

Screenshot of meditor after this change -

![Screenshot from 2025-07-09 12-41-52](https://github.com/user-attachments/assets/0e89f2c2-5a7b-4816-93a6-f11093d0f094)
