### PR TITLE
Remove unneeded import of `requests` in `dandischema.datacite`

### DIFF
--- a/dandischema/datacite/__init__.py
+++ b/dandischema/datacite/__init__.py
@@ -12,7 +12,6 @@ import re
 from typing import Any, Dict, Union
 
 from jsonschema import Draft7Validator
-import requests
 
 from ..models import (
     NAME_PATTERN,


### PR DESCRIPTION
This PR removes unneeded import of `requests` in `dandischema.datacite`.

Note:

Please ignore the following errors in the `Type-check` workflow. They are false alarms. An [issue](https://github.com/python-jsonschema/jsonschema/issues/1382) has been filed, and the jsonschema team will resolve it.

```shell
typing: commands[0]> mypy dandischema
dandischema/utils.py:220: error: Missing positional argument "registry" in call
to "Validator"  [call-arg]
            return validator_cls(schema, format_checker=validator_cls.FORM...
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~...
dandischema/utils.py:223: error: Missing positional argument "registry" in call
to "Validator"  [call-arg]
        return validator_cls(schema)
               ^~~~~~~~~~~~~~~~~~~~~
Found 2 errors in 1 file (checked 20 source files)
typing: exit 1 (8.04 seconds) /home/runner/work/dandi-schema/dandi-schema> mypy dandischema pid=2407
  typing: FAIL code 1 (23.81=setup[15.76]+cmd[8.04] seconds)
  evaluation failed :( (23.95 seconds)
  ```