### PR TITLE
Temporarily disable static type checking partially for two lines involving validators from the `jsonschema` package

### DIFF
--- a/dandischema/utils.py
+++ b/dandischema/utils.py
@@ -217,10 +217,18 @@ def jsonschema_validator(
 
     if check_format:
         # Return a validator with format checking enabled
-        return validator_cls(schema, format_checker=validator_cls.FORMAT_CHECKER)
+        # ⏳ Static type checking is temporarily disabled partially in the following line
+        #   because of https://github.com/python-jsonschema/jsonschema/issues/1382.
+        #   It should be re-enabled once the issue is resolved.
+        return validator_cls(
+            schema, format_checker=validator_cls.FORMAT_CHECKER
+        )  # type: ignore[call-arg]
 
     # Return a validator with format checking disabled
-    return validator_cls(schema)
+    # ⏳ Static type checking is temporarily disabled partially in the following line
+    #   because of https://github.com/python-jsonschema/jsonschema/issues/1382.
+    #   It should be re-enabled once the issue is resolved.
+    return validator_cls(schema)  # type: ignore[call-arg]
 
 
 def validate_json(instance: Any, validator: JsonschemaValidator) -> None:


### PR DESCRIPTION
Please checkout the individual commit message for details.