### PR TITLE
Relax various patterns defined in `dandischema.models` when DANDI Schema is not set to a vendor

### DIFF
--- a/dandischema/conf.py
+++ b/dandischema/conf.py
@@ -16,6 +16,11 @@ _UNVENDORED_DOI_PREFIX_PATTERN = r"10\.\d{4,}"
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_INSTANCE_NAME = "DANDI-ADHOC"
+"""
+The default name of the DANDI instance
+"""
+
 
 class Config(BaseSettings):
     """
@@ -34,7 +39,7 @@ class Config(BaseSettings):
 
     instance_name: Annotated[
         str, StringConstraints(pattern=rf"^{_UNVENDORED_ID_PATTERN}$")
-    ] = "DANDI-ADHOC"
+    ] = DEFAULT_INSTANCE_NAME
     """Name of the DANDI instance"""
 
     doi_prefix: Optional[

--- a/dandischema/conf.py
+++ b/dandischema/conf.py
@@ -11,7 +11,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 _MODELS_MODULE_NAME = "dandischema.models"
 """The full import name of the module containing the DANDI Pydantic models"""
 
-_UNVENDORED_ID_PATTERN = r"[A-Z][-A-Z]*"
+UNVENDORED_ID_PATTERN = r"[A-Z][-A-Z]*"
 _UNVENDORED_DOI_PREFIX_PATTERN = r"10\.\d{4,}"
 
 logger = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ class Config(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="dandi_")
 
     instance_name: Annotated[
-        str, StringConstraints(pattern=rf"^{_UNVENDORED_ID_PATTERN}$")
+        str, StringConstraints(pattern=rf"^{UNVENDORED_ID_PATTERN}$")
     ] = DEFAULT_INSTANCE_NAME
     """Name of the DANDI instance"""
 

--- a/dandischema/conf.py
+++ b/dandischema/conf.py
@@ -12,7 +12,7 @@ _MODELS_MODULE_NAME = "dandischema.models"
 """The full import name of the module containing the DANDI Pydantic models"""
 
 UNVENDORED_ID_PATTERN = r"[A-Z][-A-Z]*"
-_UNVENDORED_DOI_PREFIX_PATTERN = r"10\.\d{4,}"
+UNVENDORED_DOI_PREFIX_PATTERN = r"10\.\d{4,}"
 
 logger = logging.getLogger(__name__)
 
@@ -43,9 +43,7 @@ class Config(BaseSettings):
     """Name of the DANDI instance"""
 
     doi_prefix: Optional[
-        Annotated[
-            str, StringConstraints(pattern=rf"^{_UNVENDORED_DOI_PREFIX_PATTERN}$")
-        ]
+        Annotated[str, StringConstraints(pattern=rf"^{UNVENDORED_DOI_PREFIX_PATTERN}$")]
     ] = None
     """
     The DOI prefix at DataCite

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -36,7 +36,11 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema
 from zarr_checksum.checksum import InvalidZarrChecksum, ZarrDirectoryDigest
 
-from dandischema.conf import get_instance_config
+from dandischema.conf import (
+    DEFAULT_INSTANCE_NAME,
+    UNVENDORED_ID_PATTERN,
+    get_instance_config,
+)
 
 from .consts import DANDI_SCHEMA_VERSION
 from .digests.dandietag import DandiETag
@@ -47,7 +51,11 @@ from .utils import name2title
 _INSTANCE_CONFIG = get_instance_config()
 
 # Regex pattern for the prefix of identifiers
-ID_PATTERN = _INSTANCE_CONFIG.instance_name
+ID_PATTERN = (
+    _INSTANCE_CONFIG.instance_name
+    if _INSTANCE_CONFIG.instance_name != DEFAULT_INSTANCE_NAME
+    else UNVENDORED_ID_PATTERN
+)
 
 # The pattern that a DOI prefix of a dandiset must conform to
 DOI_PREFIX_PATTERN = (

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -88,7 +88,7 @@ _INNER_DANDI_DOI_PATTERN = (
 DANDI_DOI_PATTERN = (
     rf"^{_INNER_DANDI_DOI_PATTERN}$"
     if _INSTANCE_CONFIG.doi_prefix is not None
-    else rf"^(?:{_INNER_DANDI_DOI_PATTERN})?$"  # This matches an empty string as well
+    else rf"^({_INNER_DANDI_DOI_PATTERN}|)$"  # This matches an empty string as well
 )
 DANDI_PUBID_PATTERN = rf"^{ID_PATTERN}:{VERSION_PATTERN}$"
 DANDI_NSKEY = "dandi"  # Namespace for DANDI ontology

--- a/dandischema/models.py
+++ b/dandischema/models.py
@@ -38,6 +38,7 @@ from zarr_checksum.checksum import InvalidZarrChecksum, ZarrDirectoryDigest
 
 from dandischema.conf import (
     DEFAULT_INSTANCE_NAME,
+    UNVENDORED_DOI_PREFIX_PATTERN,
     UNVENDORED_ID_PATTERN,
     get_instance_config,
 )
@@ -61,7 +62,7 @@ ID_PATTERN = (
 DOI_PREFIX_PATTERN = (
     re.escape(_INSTANCE_CONFIG.doi_prefix)
     if _INSTANCE_CONFIG.doi_prefix is not None
-    else None
+    else UNVENDORED_DOI_PREFIX_PATTERN
 )
 
 # Use DJANGO_DANDI_WEB_APP_URL to point to a specific deployment.
@@ -81,10 +82,13 @@ UUID_PATTERN = (
 )
 ASSET_UUID_PATTERN = r"^dandiasset:" + UUID_PATTERN
 VERSION_PATTERN = r"\d{6}/\d+\.\d+\.\d+"
+_INNER_DANDI_DOI_PATTERN = (
+    rf"{DOI_PREFIX_PATTERN}/{ID_PATTERN.lower()}\.{VERSION_PATTERN}"
+)
 DANDI_DOI_PATTERN = (
-    rf"^{DOI_PREFIX_PATTERN}/{ID_PATTERN.lower()}\.{VERSION_PATTERN}$"
-    if DOI_PREFIX_PATTERN is not None
-    else None
+    rf"^{_INNER_DANDI_DOI_PATTERN}$"
+    if _INSTANCE_CONFIG.doi_prefix is not None
+    else rf"^(?:{_INNER_DANDI_DOI_PATTERN})?$"  # This matches an empty string as well
 )
 DANDI_PUBID_PATTERN = rf"^{ID_PATTERN}:{VERSION_PATTERN}$"
 DANDI_NSKEY = "dandi"  # Namespace for DANDI ontology
@@ -1873,14 +1877,11 @@ class Publishable(DandiBaseModel):
 
 _doi_field_kwargs: dict[str, Any] = {
     "title": "DOI",
+    "pattern": DANDI_DOI_PATTERN,
     "json_schema_extra": {"readOnly": True, "nskey": DANDI_NSKEY},
 }
-if DANDI_DOI_PATTERN is not None:
-    _doi_field_kwargs["pattern"] = DANDI_DOI_PATTERN
-else:
+if _INSTANCE_CONFIG.doi_prefix is None:
     _doi_field_kwargs["default"] = ""
-    # restricting the value to empty string to indicate that there is no DOI
-    _doi_field_kwargs["pattern"] = r"^$"
 
 
 class PublishedDandiset(Dandiset, Publishable):

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -792,7 +792,7 @@ def _get_field_pattern(
         # Without any environment variables set. dandischema is unvendorized.
         (
             {},
-            "DANDI-ADHOC",
+            r"[A-Z][-A-Z]*",
             None,
             {
                 "dandiset_id": "DANDI-ADHOC:001350/draft",
@@ -848,7 +848,7 @@ def _get_field_pattern(
         # Without any environment variables set. dandischema is unvendorized.
         (
             {},
-            "DANDI-ADHOC",
+            r"[A-Z][-A-Z]*",
             None,
             {
                 "dandiset_id": "DANDI-ADHOC:000005/draft",

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -793,16 +793,18 @@ def _get_field_pattern(
         (
             {},
             r"[A-Z][-A-Z]*",
-            None,
+            r"10\.\d{4,}",
             {
                 "dandiset_id": "DANDI-ADHOC:001350/draft",
                 "dandiset_identifier": "DANDI-ADHOC:001350",
                 "published_dandiset_id": "DANDI-ADHOC:001350/0.250511.1527",
+                "published_dandiset_doi": "",
             },
             {
                 "dandiset_id": "45:001350/draft",  # Invalid id prefix
                 "dandiset_identifier": "DANDI-ADHOC:001350",
                 "published_dandiset_id": "DANDI-ADHOC:001350/0.250511.1527",
+                "published_dandiset_doi": "",
             },
         ),
         (
@@ -831,17 +833,19 @@ def _get_field_pattern(
                 "instance_name": "DANDI",
             },
             "DANDI",
-            None,
+            r"10\.\d{4,}",
             {
                 "dandiset_id": "DANDI:001425/draft",
                 "dandiset_identifier": "DANDI:001425",
                 "published_dandiset_id": "DANDI:001425/0.250514.0602",
+                "published_dandiset_doi": "10.48324/dandi.001425/0.250514.0602",
             },
             {
                 "dandiset_id": "DANDI:001425/draft",
                 "dandiset_identifier": "DANDI:001425",
                 # Not matching the `ID_PATTERN` regex
                 "published_dandiset_id": "DANDI3:001425/0.250514.0602",
+                "published_dandiset_doi": "10.48324/dandi.001425/0.250514.0602",
             },
         ),
         # === EMBER DANDI instance test cases ===
@@ -849,16 +853,19 @@ def _get_field_pattern(
         (
             {},
             r"[A-Z][-A-Z]*",
-            None,
+            r"10\.\d{4,}",
             {
                 "dandiset_id": "DANDI-ADHOC:000005/draft",
-                "dandiset_identifier": "DANDI-ADHOC:000005",
+                "dandiset_identifier": "ABC:000005",
                 "published_dandiset_id": "DANDI-ADHOC:000005/0.250404.1839",
+                "published_dandiset_doi": "10.60533/ember-dandi.000005/0.250404.1839",
             },
             {
                 "dandiset_id": "DANDI-ADHOC:000005/draft",
-                "dandiset_identifier": "-DANDI-ADHOC:000005",  # Invalid id prefix
+                "dandiset_identifier": "ABC:000005",
                 "published_dandiset_id": "DANDI-ADHOC:000005/0.250404.1839",
+                # Invalid registrant code in the DOI prefix
+                "published_dandiset_doi": "10.605/ember-dandi.000005/0.250404.1839",
             },
         ),
         (
@@ -888,7 +895,7 @@ def _get_field_pattern(
 def test_vendorization(
     clear_dandischema_modules_and_set_env_vars: None,
     exp_id_pattern: str,
-    exp_doi_prefix_pattern: Optional[str],
+    exp_doi_prefix_pattern: str,
     # Fields that are valid for the vendorization
     valid_vendored_fields: dict[str, str],
     # Fields that are invalid for the vendorization
@@ -914,12 +921,11 @@ def test_vendorization(
         published_dandiset_id: str = Field(
             pattern=_get_field_pattern("id", models_.PublishedDandiset)
         )
-        if exp_doi_prefix_pattern is not None:
-            published_dandiset_doi: str = Field(
-                pattern=_get_field_pattern("doi", models_.PublishedDandiset)
-            )
+        published_dandiset_doi: str = Field(
+            pattern=_get_field_pattern("doi", models_.PublishedDandiset)
+        )
 
-        model_config = ConfigDict(strict=True, extra="forbid")
+        model_config = ConfigDict(strict=True)
 
     # Validate the valid vendored fields against the vendored patterns
     VendoredFieldModel.model_validate(valid_vendored_fields)


### PR DESCRIPTION
This PR makes regex patterns restricting instance specific IDs and DOIs less strict when either or both the instance name and DOI prefix are not provided in configuring the instance config defined in `dandischema.conf`. This allows components such as dandi-cli to be instance agnostic when carrying out metadata validation.