### PR TITLE
Make publisher info vendor specific

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,11 +23,13 @@ jobs:
             python: '3.9'
             vendored_env: dandi
             instance_name: DANDI
+            instance_identifier: 'RRID:SCR_017571'
             doi_prefix: '10.80507'
           - os: ubuntu-latest
             python: '3.9'
             vendored_env: ember-dandi
             instance_name: EMBER-DANDI
+            instance_identifier: 'RRID:SCR_026700'
             doi_prefix: '10.82754'
           - os: ubuntu-latest
             python: '3.9'
@@ -55,6 +57,11 @@ jobs:
     - name: Set DANDI_INSTANCE_NAME
       if: ${{ matrix.instance_name }}
       run: echo "DANDI_INSTANCE_NAME=${{ matrix.instance_name }}" >> "$GITHUB_ENV"
+
+    # Set only if matrix.instance_identifier is defined
+    - name: Set DANDI_INSTANCE_IDENTIFIER
+      if: ${{ matrix.instance_identifier }}
+      run: echo "DANDI_INSTANCE_IDENTIFIER=${{ matrix.instance_identifier }}" >> "$GITHUB_ENV"
 
     # Set only if matrix.doi_prefix is defined
     - name: Set DANDI_DOI_PREFIX

--- a/dandischema/conf.py
+++ b/dandischema/conf.py
@@ -14,6 +14,15 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 _MODELS_MODULE_NAME = "dandischema.models"
 """The full import name of the module containing the DANDI Pydantic models"""
 
+INSTANCE_IDENTIFIER_PATTERN = r"RRID:\S+"
+"""
+The pattern of the ID identifying the DANDI service instance
+
+Note
+----
+    This pattern currently only allows Research Resource Identifiers (RRIDs).
+"""
+
 UNVENDORED_ID_PATTERN = r"[A-Z][-A-Z]*"
 UNVENDORED_DOI_PREFIX_PATTERN = r"10\.\d{4,}"
 
@@ -96,6 +105,23 @@ class Config(BaseSettings):
         ),
     ] = DEFAULT_INSTANCE_NAME
     """Name of the DANDI instance"""
+
+    instance_identifier: Annotated[
+        str,
+        StringConstraints(pattern=rf"^{INSTANCE_IDENTIFIER_PATTERN}$"),
+        Field(
+            validation_alias=AliasChoices(
+                "dandi_instance_identifier", "django_dandi_instance_identifier"
+            )
+        ),
+    ]
+    """
+    ID identifying the DANDI service instance
+
+    Note
+    ----
+        This field currently only accepts Research Resource Identifiers (RRIDs).
+    """
 
     doi_prefix: Optional[
         Annotated[str, StringConstraints(pattern=rf"^{UNVENDORED_DOI_PREFIX_PATTERN}$")]

--- a/dandischema/conf.py
+++ b/dandischema/conf.py
@@ -106,15 +106,17 @@ class Config(BaseSettings):
     ] = DEFAULT_INSTANCE_NAME
     """Name of the DANDI instance"""
 
-    instance_identifier: Annotated[
-        str,
-        StringConstraints(pattern=rf"^{INSTANCE_IDENTIFIER_PATTERN}$"),
-        Field(
-            validation_alias=AliasChoices(
-                "dandi_instance_identifier", "django_dandi_instance_identifier"
-            )
+    instance_identifier: Optional[
+        Annotated[
+            str,
+            StringConstraints(pattern=rf"^{INSTANCE_IDENTIFIER_PATTERN}$"),
+        ]
+    ] = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "dandi_instance_identifier", "django_dandi_instance_identifier"
         ),
-    ]
+    )
     """
     ID identifying the DANDI service instance
 

--- a/dandischema/datacite/__init__.py
+++ b/dandischema/datacite/__init__.py
@@ -12,7 +12,6 @@ import re
 from typing import Any, Dict, Union
 
 from jsonschema import Draft7Validator
-import requests
 
 from dandischema.conf import get_instance_config
 

--- a/dandischema/datacite/__init__.py
+++ b/dandischema/datacite/__init__.py
@@ -14,6 +14,8 @@ from typing import Any, Dict, Union
 from jsonschema import Draft7Validator
 import requests
 
+from dandischema.conf import get_instance_config
+
 from ..models import (
     NAME_PATTERN,
     LicenseType,
@@ -118,6 +120,9 @@ def to_datacite(
     publish: bool = False,
 ) -> dict:
     """Convert published Dandiset metadata to Datacite"""
+
+    instance_config = get_instance_config()
+
     if not isinstance(meta, PublishedDandiset):
         meta = PublishedDandiset(**meta)
 
@@ -143,13 +148,15 @@ def to_datacite(
     attributes["descriptions"] = [
         {"description": meta.description, "descriptionType": "Abstract"}
     ]
+
     attributes["publisher"] = {
-        "name": "DANDI Archive",
+        "name": f"{instance_config.instance_name} Archive",
         "schemeUri": "https://scicrunch.org/resolver/",
-        "publisherIdentifier": "https://scicrunch.org/resolver/RRID:SCR_017571",
+        "publisherIdentifier": f"https://scicrunch.org/resolver/{instance_config.instance_identifier}",
         "publisherIdentifierScheme": "RRID",
         "lang": "en",
     }
+
     attributes["publicationYear"] = str(meta.datePublished.year)
     # not sure about it dandi-api had "resourceTypeGeneral": "NWB"
     attributes["types"] = {

--- a/dandischema/datacite/tests/test_datacite.py
+++ b/dandischema/datacite/tests/test_datacite.py
@@ -8,6 +8,7 @@ from jsonschema import Draft7Validator
 import pytest
 import requests
 
+from dandischema.conf import get_instance_config
 from dandischema.models import (
     LicenseType,
     PublishedDandiset,
@@ -27,6 +28,8 @@ from dandischema.tests.utils import (
 )
 
 from .. import _get_datacite_schema, _licenses_to_rights_list, to_datacite
+
+_INSTANCE_CONFIG = get_instance_config()
 
 
 class TestLicensesToRightsList:
@@ -274,8 +277,9 @@ def test_datacite(dandi_id: str, schema: Any) -> None:
                 "publisher": (
                     None,
                     {
-                        "name": "DANDI Archive",
-                        "publisherIdentifier": "https://scicrunch.org/resolver/RRID:SCR_017571",
+                        "name": f"{_INSTANCE_CONFIG.instance_name} Archive",
+                        "publisherIdentifier": f"https://scicrunch.org/resolver/"
+                        f"{_INSTANCE_CONFIG.instance_identifier}",
                         "publisherIdentifierScheme": "RRID",
                         "schemeUri": "https://scicrunch.org/resolver/",
                         "lang": "en",
@@ -597,8 +601,9 @@ def test_datacite_publish(metadata_basic: Dict[str, Any]) -> None:
                 ],
                 "publicationYear": "1970",
                 "publisher": {
-                    "name": "DANDI Archive",
-                    "publisherIdentifier": "https://scicrunch.org/resolver/RRID:SCR_017571",
+                    "name": f"{_INSTANCE_CONFIG.instance_name} Archive",
+                    "publisherIdentifier": f"https://scicrunch.org/resolver/"
+                    f"{_INSTANCE_CONFIG.instance_identifier}",
                     "publisherIdentifierScheme": "RRID",
                     "schemeUri": "https://scicrunch.org/resolver/",
                     "lang": "en",

--- a/dandischema/tests/test_conf.py
+++ b/dandischema/tests/test_conf.py
@@ -20,6 +20,7 @@ def test_get_instance_config() -> None:
 
 _FOO_CONFIG_DICT_BY_FIELD_NAME = {
     "instance_name": "FOO",
+    "instance_identifier": "RRID:ABC_123456",
     "doi_prefix": "10.1234",
     "licenses": ["spdx:AdaCore-doc", "spdx:AGPL-3.0-or-later", "spdx:NBPL-1.0"],
 }
@@ -34,6 +35,10 @@ FOO_CONFIG_ENV_VARS = {
 
 class TestConfig:
     @pytest.mark.parametrize(
+        "clear_dandischema_modules_and_set_env_vars", [{}], indirect=True
+    )
+    @pytest.mark.usefixtures("clear_dandischema_modules_and_set_env_vars")
+    @pytest.mark.parametrize(
         "instance_name",
         ["DANDI-ADHOC", "DANDI-TEST", "DANDI", "DANDI--TEST", "DANDI-TE-ST"],
     )
@@ -45,6 +50,10 @@ class TestConfig:
 
         Config(dandi_instance_name=instance_name)
 
+    @pytest.mark.parametrize(
+        "clear_dandischema_modules_and_set_env_vars", [{}], indirect=True
+    )
+    @pytest.mark.usefixtures("clear_dandischema_modules_and_set_env_vars")
     @pytest.mark.parametrize("instance_name", ["-DANDI", "dandi", "DANDI0", "DANDI*"])
     def test_invalid_instance_name(self, instance_name: str) -> None:
         """
@@ -59,6 +68,10 @@ class TestConfig:
         assert exc_info.value.errors()[0]["loc"] == ("dandi_instance_name",)
 
     @pytest.mark.parametrize(
+        "clear_dandischema_modules_and_set_env_vars", [{}], indirect=True
+    )
+    @pytest.mark.usefixtures("clear_dandischema_modules_and_set_env_vars")
+    @pytest.mark.parametrize(
         "instance_identifier", [None, "RRID:ABC_123456", "RRID:SCR_1234567891234"]
     )
     def test_valid_instance_identifier(
@@ -71,6 +84,10 @@ class TestConfig:
 
         Config(dandi_instance_identifier=instance_identifier)
 
+    @pytest.mark.parametrize(
+        "clear_dandischema_modules_and_set_env_vars", [{}], indirect=True
+    )
+    @pytest.mark.usefixtures("clear_dandischema_modules_and_set_env_vars")
     @pytest.mark.parametrize("instance_identifier", ["", "RRID:AB C", "ID:ABC_123456"])
     def test_invalid_instance_identifier(self, instance_identifier: str) -> None:
         """
@@ -84,6 +101,10 @@ class TestConfig:
         assert len(exc_info.value.errors()) == 1
         assert exc_info.value.errors()[0]["loc"] == ("dandi_instance_identifier",)
 
+    @pytest.mark.parametrize(
+        "clear_dandischema_modules_and_set_env_vars", [{}], indirect=True
+    )
+    @pytest.mark.usefixtures("clear_dandischema_modules_and_set_env_vars")
     def test_without_instance_identifier_with_doi_prefix(self) -> None:
         """
         Test instantiating `dandischema.conf.Config` without an instance identifier
@@ -97,6 +118,10 @@ class TestConfig:
             Config(dandi_doi_prefix="10.1234")
 
     @pytest.mark.parametrize(
+        "clear_dandischema_modules_and_set_env_vars", [{}], indirect=True
+    )
+    @pytest.mark.usefixtures("clear_dandischema_modules_and_set_env_vars")
+    @pytest.mark.parametrize(
         "doi_prefix", ["10.1234", "10.5678", "10.12345678", "10.987654321"]
     )
     def test_valid_doi_prefix(self, doi_prefix: str) -> None:
@@ -105,8 +130,16 @@ class TestConfig:
         """
         from dandischema.conf import Config
 
-        Config(dandi_doi_prefix=doi_prefix)
+        Config(
+            # Instance identifier must be provided if doi_prefix is provided
+            dandi_instance_identifier="RRID:SCR_017571",
+            dandi_doi_prefix=doi_prefix,
+        )
 
+    @pytest.mark.parametrize(
+        "clear_dandischema_modules_and_set_env_vars", [{}], indirect=True
+    )
+    @pytest.mark.usefixtures("clear_dandischema_modules_and_set_env_vars")
     @pytest.mark.parametrize("doi_prefix", ["1234", ".1234", "1.1234", "10.123"])
     def test_invalid_doi_prefix(self, doi_prefix: str) -> None:
         """
@@ -115,11 +148,19 @@ class TestConfig:
         from dandischema.conf import Config
 
         with pytest.raises(ValidationError) as exc_info:
-            Config(dandi_doi_prefix=doi_prefix)
+            Config(
+                # Instance identifier must be provided if doi_prefix is provided
+                dandi_instance_identifier="RRID:SCR_017571",
+                dandi_doi_prefix=doi_prefix,
+            )
 
         assert len(exc_info.value.errors()) == 1
         assert exc_info.value.errors()[0]["loc"] == ("dandi_doi_prefix",)
 
+    @pytest.mark.parametrize(
+        "clear_dandischema_modules_and_set_env_vars", [{}], indirect=True
+    )
+    @pytest.mark.usefixtures("clear_dandischema_modules_and_set_env_vars")
     @pytest.mark.parametrize(
         "licenses",
         [
@@ -174,6 +215,10 @@ class TestConfig:
 
         assert config.licenses == {License(license_) for license_ in licenses}
 
+    @pytest.mark.parametrize(
+        "clear_dandischema_modules_and_set_env_vars", [{}], indirect=True
+    )
+    @pytest.mark.usefixtures("clear_dandischema_modules_and_set_env_vars")
     @pytest.mark.parametrize(
         "licenses",
         [

--- a/dandischema/tests/test_conf.py
+++ b/dandischema/tests/test_conf.py
@@ -59,6 +59,44 @@ class TestConfig:
         assert exc_info.value.errors()[0]["loc"] == ("dandi_instance_name",)
 
     @pytest.mark.parametrize(
+        "instance_identifier", [None, "RRID:ABC_123456", "RRID:SCR_1234567891234"]
+    )
+    def test_valid_instance_identifier(
+        self, instance_identifier: Optional[str]
+    ) -> None:
+        """
+        Test instantiating `dandischema.conf.Config` with a valid instance identifier
+        """
+        from dandischema.conf import Config
+
+        Config(dandi_instance_identifier=instance_identifier)
+
+    @pytest.mark.parametrize("instance_identifier", ["", "RRID:AB C", "ID:ABC_123456"])
+    def test_invalid_instance_identifier(self, instance_identifier: str) -> None:
+        """
+        Test instantiating `dandischema.conf.Config` with an invalid instance identifier
+        """
+        from dandischema.conf import Config
+
+        with pytest.raises(ValidationError) as exc_info:
+            Config(dandi_instance_identifier=instance_identifier)
+
+        assert len(exc_info.value.errors()) == 1
+        assert exc_info.value.errors()[0]["loc"] == ("dandi_instance_identifier",)
+
+    def test_without_instance_identifier_with_doi_prefix(self) -> None:
+        """
+        Test instantiating `dandischema.conf.Config` without an instance identifier
+        when a DOI prefix is provided
+        """
+        from dandischema.conf import Config
+
+        with pytest.raises(
+            ValidationError, match="`instance_identifier` must also be set."
+        ):
+            Config(dandi_doi_prefix="10.1234")
+
+    @pytest.mark.parametrize(
         "doi_prefix", ["10.1234", "10.5678", "10.12345678", "10.987654321"]
     )
     def test_valid_doi_prefix(self, doi_prefix: str) -> None:

--- a/dandischema/tests/test_models.py
+++ b/dandischema/tests/test_models.py
@@ -811,6 +811,7 @@ def _get_field_pattern(
         (
             {
                 "instance_name": "DANDI",
+                "instance_identifier": "RRID:ABC_123456",
                 "doi_prefix": "10.48324",
             },
             "DANDI",
@@ -872,6 +873,7 @@ def _get_field_pattern(
         (
             {
                 "instance_name": "EMBER-DANDI",
+                "instance_identifier": "RRID:ABC_123456",
                 "doi_prefix": "10.60533",
             },
             "EMBER-DANDI",


### PR DESCRIPTION
This PR closes https://github.com/dandi/dandi-schema/issues/303.

todos:

- [x] Provide RRID for EMBER-DANDI instance identifier in the `Tests` GitHub workflow
- [ ] Decide on the needed change in DANDI Archive in regard to its call to `to_datecite()` particularly when `instance_identifier` is `None`
- [ ] Decide on the needed change in DANDI Client in regard to its call to `to_datecite()` particularly when `instance_identifier` is `None`. Postponing at this point?