### PR TITLE
Handle `instance_identifier` in instance config being `None` in DataCite metadata generation

### DIFF
--- a/dandischema/datacite/__init__.py
+++ b/dandischema/datacite/__init__.py
@@ -153,7 +153,7 @@ def to_datacite(
         "name": f"{instance_config.instance_name} Archive",
         "lang": "en",
     }
-    if instance_config.instance_identifier is not None:
+    if instance_config.instance_identifier:
         attributes["publisher"].update(
             {
                 "schemeUri": "https://scicrunch.org/resolver/",

--- a/dandischema/datacite/__init__.py
+++ b/dandischema/datacite/__init__.py
@@ -148,13 +148,19 @@ def to_datacite(
         {"description": meta.description, "descriptionType": "Abstract"}
     ]
 
+    # Populate publisher info
     attributes["publisher"] = {
         "name": f"{instance_config.instance_name} Archive",
-        "schemeUri": "https://scicrunch.org/resolver/",
-        "publisherIdentifier": f"https://scicrunch.org/resolver/{instance_config.instance_identifier}",
-        "publisherIdentifierScheme": "RRID",
         "lang": "en",
     }
+    if instance_config.instance_identifier is not None:
+        attributes["publisher"].update(
+            {
+                "schemeUri": "https://scicrunch.org/resolver/",
+                "publisherIdentifier": f"https://scicrunch.org/resolver/{instance_config.instance_identifier}",
+                "publisherIdentifierScheme": "RRID",
+            }
+        )
 
     attributes["publicationYear"] = str(meta.datePublished.year)
     # not sure about it dandi-api had "resourceTypeGeneral": "NWB"


### PR DESCRIPTION
This PR handles the situation where the `instance_identifier` field of the instance config defined in `dandischema.conf` is `None` in generating the DataCite metadata.

This solution is based on a close reading of the DataCite metadata documentation at https://datacite-metadata-schema.readthedocs.io/en/4.6/properties/publisher/ which indicates that even though the `publisher` field is required in the metadata, its sub-fields, `publisherIdentifier`, `publisherIdentifierScheme`, and `schemeUri` are optional.

**Note**
Filed an [issue](https://github.com/datacite/schema-docs/issues/41) regarding DataCite Metadata Schema documentation, in part, to confirm the interpretation of the documentation which this PR is based on.